### PR TITLE
test(cli/cmd): handle powershell

### DIFF
--- a/cli/cmd.test.ts
+++ b/cli/cmd.test.ts
@@ -9,7 +9,14 @@ import { cmd, CmdError } from "./cmd.ts";
 
 describe("cmd", () => {
   it("returns stdout", async () =>
-    assertEquals(await cmd("echo Hello!"), "Hello!"));
+    assertEquals(
+      await cmd(
+        Deno.build.os === "windows"
+          ? "powershell.exe echo Hello!"
+          : "echo Hello!",
+      ),
+      "Hello!",
+    ));
 
   describe("options.fullResult", () => {
     const fullResult = true as const;


### PR DESCRIPTION
Test for `cli/cmd` using "echo" failed in PowerShell:  

![image](https://user-images.githubusercontent.com/92492121/233859760-064057ad-cd60-41d3-8556-41835f84a804.png)

Added conditional logic to test based on OS.