### PR TITLE
feat(cli/cmd): don't throw with `fullResult` option

### DIFF
--- a/cli/cmd.stub.ts
+++ b/cli/cmd.stub.ts
@@ -3,7 +3,7 @@ import { cmd, CmdOptions, CmdResult } from "./cmd.ts";
 
 export type CmdStub = Stub<{ cmd: typeof cmd }>;
 
-const DEFAULT_VALUE = { stdout: "", stderr: "", success: true, exitCode: 0 };
+const DEFAULT_VALUE = { stdout: "", stderr: "", success: true, code: 0 };
 
 export function stubCmd(
   internalsObj: { cmd: typeof cmd },

--- a/cli/cmd.test.ts
+++ b/cli/cmd.test.ts
@@ -18,19 +18,6 @@ describe("cmd", () => {
       "Hello!",
     ));
 
-  describe("options.fullResult", () => {
-    const fullResult = true as const;
-
-    it("indicates success", async () =>
-      assertEquals((await cmd("deno -V", { fullResult })).success, true));
-
-    it("provides the exit code", async () =>
-      assertEquals((await cmd("deno -V", { fullResult })).exitCode, 0));
-
-    it("provides stderr", async () =>
-      assertEquals((await cmd("deno -V", { fullResult })).stderr, ""));
-  });
-
   it("throws custom error on fail", async () =>
     void await assertRejects(() => cmd("deno LMAO"), CmdError));
 
@@ -41,10 +28,27 @@ describe("cmd", () => {
 
     it("provides fullResult", async () =>
       void await cmd("deno LMAO").catch((error) => {
+        assert(error instanceof CmdError);
         assertEquals(error.stdout, "");
         assertEquals(error.success, false);
-        assertEquals(error.exitCode, 1);
+        assertEquals(error.code, 1);
         assert(error.stderr.includes("unrecognized subcommand"));
       }));
+  });
+
+  describe("options.fullResult", () => {
+    const fullResult = true as const;
+
+    it("indicates success", async () =>
+      assertEquals((await cmd("deno -V", { fullResult })).success, true));
+
+    it("provides the exit code", async () =>
+      assertEquals((await cmd("deno -V", { fullResult })).code, 0));
+
+    it("provides stderr", async () =>
+      assertEquals((await cmd("deno -V", { fullResult })).stderr, ""));
+
+    it("doesn't throw", async () =>
+      assertEquals((await cmd("deno LMAO", { fullResult })).success, false));
   });
 });

--- a/md/codeBlock/eval.test.ts
+++ b/md/codeBlock/eval.test.ts
@@ -5,7 +5,6 @@ import {
   describe,
   it,
 } from "../../_deps/testing.ts";
-import { CmdError } from "../../cli/cmd.ts";
 import {
   evaluate,
   evaluateAll,
@@ -43,7 +42,7 @@ describe("evaluate", () => {
     const result = await evaluate(fenced.create(throws, { lang: "ts" }));
 
     assertEquals(result.success, false);
-    assertEquals(result.exitCode, 1);
+    assertEquals(result.code, 1);
     assertEquals(result.stdout, "");
     assert(result.stderr.includes("throw new Error()"));
   });
@@ -101,15 +100,13 @@ describe("evaluateAll", () => {
       assertEquals(results.size, 2);
       for (const [node, result] of results) {
         assert(node.type === "fenced");
-        if (result instanceof CmdError) {
-          assertEquals(result.success, false);
-          assertEquals(result.exitCode, 1);
+        assert(!(result instanceof Error));
+        if (!result.success) {
+          assertEquals(result.code, 1);
           assertEquals(result.stdout, "");
           assert(result.stderr.includes("throw new Error()"));
         } else {
-          assert(!(result instanceof Error));
-          assertEquals(result.success, true);
-          assertEquals(result.exitCode, 0);
+          assertEquals(result.code, 0);
           assertEquals(result.stderr, "");
           assertEquals(result.stdout, '"Hello!"');
         }

--- a/md/codeBlock/eval.ts
+++ b/md/codeBlock/eval.ts
@@ -1,6 +1,6 @@
 import { parse as parseCodeBlock } from "./parse.ts";
 import { findAll as findAllCodeBlocks } from "./findAll.ts";
-import { cmd, CmdError, CmdResult } from "../../cli/cmd.ts";
+import { cmd, CmdResult } from "../../cli/cmd.ts";
 
 export class IndentedCodeBlockError extends Error {
   constructor() {
@@ -48,21 +48,17 @@ function _getCode(
 }
 
 async function _eval(code: string) {
-  try {
-    return await cmd(
-      ["deno", "eval", "-q", "--check", "--ext=ts", code],
-      { fullResult: true },
-    );
-  } catch (error) {
-    return error as CmdError;
-  }
+  return await cmd(
+    ["deno", "eval", "-q", "--check", "--ext=ts", code],
+    { fullResult: true },
+  );
 }
 
 /** Passes a code block to `deno eval`. */
 export async function evaluate(
   codeBlock: string,
   { replace = [] }: EvaluateOptions = {},
-): Promise<CmdResult | CmdError> {
+) {
   const details = parseCodeBlock(codeBlock);
   const code = _getCode(details, replace);
 
@@ -78,7 +74,6 @@ export async function evaluateAll(
   const results: Map<
     Details,
     | CmdResult
-    | CmdError
     | IndentedCodeBlockError
     | NoLanguageError
     | UnknownLanguageError


### PR DESCRIPTION
See #27