### PR TITLE
refactor(types): require explicit return types

### DIFF
--- a/cli/cmd.ts
+++ b/cli/cmd.ts
@@ -51,7 +51,7 @@ export async function cmd(
 export async function cmd(
   command: string | string[],
   { cwd, env, fullResult = false }: CmdOptions = {},
-) {
+): Promise<string | CmdResult> {
   const [cmd, ...args] = Array.isArray(command) ? command : command.split(" ");
 
   const res = await new Deno.Command(cmd, { args, cwd, env }).output();

--- a/collection/largest.ts
+++ b/collection/largest.ts
@@ -17,15 +17,13 @@ export function largest<P extends string, T extends { [K in P]: number }>(
   property: P,
   items: Iterable<T>,
 ): T[];
-export function largest(
-  // deno-lint-ignore no-explicit-any
-  arg1: string | Iterable<any>,
-  // deno-lint-ignore no-explicit-any
-  arg2?: Iterable<any>,
-) {
+export function largest<P extends string, T extends { [K in P]: number }>(
+  arg1: P | Iterable<T>,
+  arg2?: Iterable<T>,
+): T[] {
   const [property, items] = typeof arg1 === "string"
     ? [arg1, arg2!]
-    : ["length", arg1];
+    : ["length" as P, arg1];
 
   const largest = [];
   let largestSize = -Infinity;

--- a/collection/smallest.ts
+++ b/collection/smallest.ts
@@ -17,15 +17,13 @@ export function smallest<P extends string, T extends { [K in P]: number }>(
   property: P,
   items: Iterable<T>,
 ): T[];
-export function smallest(
-  // deno-lint-ignore no-explicit-any
-  arg1: string | Iterable<any>,
-  // deno-lint-ignore no-explicit-any
-  arg2?: Iterable<any>,
-) {
+export function smallest<P extends string, T extends { [K in P]: number }>(
+  arg1: P | Iterable<T>,
+  arg2?: Iterable<T>,
+): T[] {
   const [property, items] = typeof arg1 === "string"
     ? [arg1, arg2!]
-    : ["length", arg1];
+    : ["length" as P, arg1];
 
   const smallest = [];
   let smallestSize = Infinity;

--- a/deno.json
+++ b/deno.json
@@ -1,5 +1,10 @@
 {
   "fmt": { "proseWrap": "never" },
+  "lint": {
+    "rules": {
+      "include": ["explicit-function-return-type"]
+    }
+  },
   "lock": false,
   "tasks": {
     "test-readme": "deno run -A md/script/evalCodeBlocks.ts ./readme.md https://deno.land/x/handy .",

--- a/fs/globImport.ts
+++ b/fs/globImport.ts
@@ -1,17 +1,29 @@
 import { glob } from "./glob.ts";
 import { toFileUrl } from "../_deps/path.ts";
 
-/** A map from absolute filepaths to `import()` functions. */
+/** A callback that will open a file and return its contents.
+ *
+ * @example
+ * const fn: ImportLike = () => import("./someModule.ts")
+ * const module = await fn()
+ *
+ * @example
+ * const fn: ImportLike = () =>
+ *   Deno.readTextFile("./someFile.txt")
+ * const module = await fn() */
 // deno-lint-ignore no-explicit-any
-export type Modules = Record<string, () => Promise<any>>;
+export type ImportLike = () => Promise<any>;
 
-/** A map from absolute filepaths to `import()` results. */
+/** A map from absolute filepaths to `import()`-like functions which, when
+ * called, return the associated file's contents. */
+export type Modules = Record<string, ImportLike>;
+
+/** A map from absolute filepaths to the contents of those files. */
 // deno-lint-ignore no-explicit-any
 export type EagerModules = Record<string, any>;
 
-/** Given a full `filePath`, return an import function. */
-// deno-lint-ignore no-explicit-any
-export type ImportFactory = (filePath: string) => () => Promise<any>;
+/** Given a full `filePath`, return an `import()`-like function. */
+export type ImportFactory = (filePath: string) => ImportLike;
 
 export type FileHandler = ImportFactory | {
   [Extension: string]: ImportFactory;
@@ -20,7 +32,7 @@ export type FileHandler = ImportFactory | {
 export class FileHandlerError extends Error {
   constructor(
     public readonly filePath: string,
-    public readonly handlers: Record<string, ImportFactory>,
+    public readonly handlers: Record<string, unknown>,
   ) {
     super(
       "Could not find a file handler for the following file:" +
@@ -38,8 +50,7 @@ export const DEFAULT_FILE_HANDLER: FileHandler = {
 export type GlobImportOptions = {
   /** Return file contents rather than import functions. */
   eager?: boolean;
-  /**
-   * A function that turns a file path into an import function, or an object
+  /** A function that turns a file path into an import function, or an object
    * mapping file extensions to such functions. When a file is found, it will
    * match against the first entry that matches it. Use an empty string as an
    * extension for a fallback handler.
@@ -51,20 +62,19 @@ export type GlobImportOptions = {
    * const fileHandler = (filePath) => () => Deno.readTextFile(filePath);
    *
    * @example
-   * const fileHandlers = {
+   * const fileHandler = {
    *   ".ts": (filePath) => () => import(filePath),
-   *   ".json": (path) => () => Deno.readTextFile(path).then(JSON.parse),
+   *   ".json": (path) => () =>
+   *     Deno.readTextFile(path).then(JSON.parse),
    *   "": (filePath) => () => Deno.readTextFile(filePath), // fallback
-   * }
-   */
+   * } */
   fileHandler?: FileHandler;
 };
 
 function makeImportFunction(
   filePath: string,
   handlers: Record<string, ImportFactory>,
-  // deno-lint-ignore no-explicit-any
-): () => Promise<any> {
+): ImportLike {
   for (const [extension, handler] of Object.entries(handlers)) {
     if (filePath.endsWith(extension)) return handler(filePath);
   }
@@ -72,35 +82,33 @@ function makeImportFunction(
   throw new FileHandlerError(filePath, handlers);
 }
 
-/**
- * Given a glob pattern, returns a mapping from the identified filepaths to
- * imports. Like the `glob` utility, this expects an absolute or relative glob
- * pattern rather than a separate base path.
+/** Given a glob pattern, returns a mapping from the identified filepaths to
+ * `ImportLike` callback functions which will return the contents of the
+ * associated file. Like the `glob` utility, this expects an absolute or
+ * relative glob pattern rather than a separate base path.
  *
- * By default, import functions are returned without being called. When
- * `options.eager` is set to `true`, each import function is called and the
- * *contents* of those files are returned instead.
- *
- * Optionally you can pass a map of `FileHandlers`, which describe how to
- * create an import function for a given file extension. See the example below.
+ * Only handles `.ts` files by default. Optionally you can pass a `FileHandler`
+ * describing how to open file types by extension. See the example below.
  *
  * @example
  * const pattern = path.resolve(".", "**", "*.ts")
  * const modules = await globImport(pattern)
  *
- * for (const [filePath, importFn] of Object.entries(modules)) {
+ * for (const [filePath, importLike] of Object.entries(modules)) {
  *    console.log(`Importing ${filePath}...`)
- *    const module = await importFn()
+ *    const module = await importLike()
  * }
  *
  * @example
  * const pattern = path.resolve(".", "**", "*.json")
- * const eager = true // will call each import function
  * const fileHandler = (filePath) =>
  *     () => Deno.readTextFile(filePath).then(JSON.parse)
  *
- * const jsonData = await globImport(pattern, { eager, fileHandler })
- * console.log(jsonData.someFile.someKey[0].someOtherKey...)
+ * const modules = await globImport(pattern, { fileHandler })
+ * for (const [filePath, importLike] of Object.entries(modules)) {
+ *   console.log(`Importing ${filePath}...`)
+ *   const json = await importLike()
+ * }
  *
  * @example
  * const pattern = path.resolve(".", "**", "*.*")
@@ -109,12 +117,29 @@ function makeImportFunction(
  *   "": (filePath) => () => Deno.readTextFile(filePath), // fallback
  * }
  *
- * const modules = await globImport(pattern, { fileHandler })
- */
+ * const modules = await globImport(pattern, { fileHandler }) */
 export async function globImport(
   globPattern: string,
   options?: { eager?: false; fileHandler?: FileHandler },
 ): Promise<Modules>;
+/** Given a glob pattern, returns a mapping from the identified filepaths to the
+ * contents of those files.
+ *
+ * Optionally you can pass a `FileHandler` describing how to open file types by
+ * extension. See the example below.
+ *
+ * @example
+ * const pattern = path.resolve(".", "**", "*.ts")
+ * const modules = await globImport(pattern, { eager: true })
+ * modules["/path/to/someModule.ts"].someExportedFunction()
+ *
+ * @example
+ * const pattern = path.resolve(".", "**", "*.json")
+ * const fileHandler = (filePath) =>
+ *     () => Deno.readTextFile(filePath).then(JSON.parse)
+ *
+ * const data = await globImport(pattern, { eager: true, fileHandler })
+ * data["/path/to/someFile.json"].someKey[0].someOtherKey */
 export async function globImport(
   globPattern: string,
   options: { eager: true; fileHandler?: FileHandler },
@@ -129,11 +154,11 @@ export async function globImport(
   const entries = await Promise.all(
     filePaths.map(async (filePath) => {
       filePath = toFileUrl(filePath).href;
-      const importFunction = typeof fileHandler === "function"
+      const importLike = typeof fileHandler === "function"
         ? fileHandler(filePath)
         : makeImportFunction(filePath, fileHandler);
 
-      return [filePath, eager ? await importFunction() : importFunction];
+      return [filePath, eager ? await importLike() : importLike];
     }),
   );
 

--- a/fs/globImport.ts
+++ b/fs/globImport.ts
@@ -63,7 +63,8 @@ export type GlobImportOptions = {
 function makeImportFunction(
   filePath: string,
   handlers: Record<string, ImportFactory>,
-) {
+  // deno-lint-ignore no-explicit-any
+): () => Promise<any> {
   for (const [extension, handler] of Object.entries(handlers)) {
     if (filePath.endsWith(extension)) return handler(filePath);
   }
@@ -121,7 +122,7 @@ export async function globImport(
 export async function globImport(
   globPattern: string,
   options: GlobImportOptions = {},
-) {
+): Promise<Modules | EagerModules> {
   const { eager = false, fileHandler = DEFAULT_FILE_HANDLER } = options;
   const filePaths = await glob(globPattern);
 

--- a/git/commit/conventional.test.ts
+++ b/git/commit/conventional.test.ts
@@ -15,7 +15,7 @@ import {
   stringify,
 } from "./conventional.ts";
 
-function msg(str: string) {
+function msg(str: string): string {
   return dedent(str).trim();
 }
 

--- a/git/commit/conventional.ts
+++ b/git/commit/conventional.ts
@@ -59,7 +59,14 @@ const FOOTER_SEGMENT_REGEX = /^((\S+|BREAKING CHANGE): .|\S+ #.)/;
 const FOOTER_REGEX =
   /^((?<colonKey>[\S]+|BREAKING CHANGE): (?<colonValue>[\s\S]*)|(?<hashKey>[\S]+) (?<hashValue>#[\s\S]*))/;
 
-function parseSubject(line: string) {
+function parseSubject(
+  line: string,
+): readonly [
+  type: string,
+  scope: string,
+  breakingChange: true | undefined,
+  description: string,
+] {
   const { type, breaking, scope, description } =
     line.match(SUBJECT_REGEX)?.groups ?? {};
 
@@ -68,7 +75,9 @@ function parseSubject(line: string) {
   return [type, scope, breakingChange, description] as const;
 }
 
-function parseRemainder(remainder: string) {
+function parseRemainder(
+  remainder: string,
+): readonly [bodySegments: string[], footers: ConventionalCommitFooter[]] {
   const bodySegments = [] as string[];
   const footers = [] as ConventionalCommitFooter[];
 

--- a/git/script/makeReleaseNotes.ts
+++ b/git/script/makeReleaseNotes.ts
@@ -30,7 +30,9 @@ async function commits(
   commit?: string,
   types?: string[],
   inclusive = false,
-) {
+): Promise<
+  readonly [Record<string, CommitInfo[]>, Record<string, CommitInfo[]>]
+> {
   commit ??= await getLatestTag();
   const rawCommits = (await getCommitSpan([commit, "HEAD"], { inclusive }))
     .reverse();
@@ -75,14 +77,14 @@ async function commits(
   return [breaking, nonBreaking] as const;
 }
 
-function typeName(type: string, typeNames: Record<string, string>) {
+function typeName(type: string, typeNames: Record<string, string>): string {
   return typeNames[type] ?? `${type[0].toUpperCase()}${type.slice(1)} Commits`;
 }
 
 function sortTypes(
   breaking: Record<string, CommitInfo[]>,
   nonBreaking: Record<string, CommitInfo[]>,
-) {
+): string[] {
   return [
     ...new Set([
       ...Object.keys(breaking),
@@ -94,7 +96,7 @@ function sortTypes(
 function asListItem(
   { type, scope, description, body, footers, breakingChange, hash }: CommitInfo,
   groupByType?: boolean,
-) {
+): string {
   const typeAndScope = groupByType
     ? scope ? `(${scope})` : ""
     : scope
@@ -126,7 +128,7 @@ function asListItem(
   return listItem;
 }
 
-function asUnorderedList(commits: CommitInfo[], groupByType = false) {
+function asUnorderedList(commits: CommitInfo[], groupByType = false): string {
   return commits.map((c) => asListItem(c, groupByType)).join("\n\n");
 }
 
@@ -134,7 +136,7 @@ function releaseNotesUngrouped(
   sortedTypes: string[],
   breaking: Record<string, CommitInfo[]>,
   nonBreaking: Record<string, CommitInfo[]>,
-) {
+): string {
   let breakingMarkdown = "";
   let nonBreakingMarkdown = "";
 
@@ -157,7 +159,7 @@ function releaseNotesByType(
   typeNames: Record<string, string>,
   breaking: Record<string, CommitInfo[]>,
   nonBreaking: Record<string, CommitInfo[]>,
-) {
+): string {
   typeNames = { ...TYPE_NAMES, ...typeNames };
   let markdown = "";
 
@@ -205,7 +207,7 @@ export type MakeReleaseNotesOptions = {
 export async function makeReleaseNotes(
   { cwd, commit, inclusive, verbose, groupByType, types, typeNames = {} }:
     MakeReleaseNotesOptions = {},
-) {
+): Promise<string> {
   if (cwd) Deno.chdir(cwd);
 
   const log = (message: string) => verbose && console.log(message);
@@ -218,7 +220,7 @@ export async function makeReleaseNotes(
   return markdown.trim();
 }
 
-function typeNames(flags: Record<string, unknown>) {
+function typeNames(flags: Record<string, unknown>): Record<string, string> {
   const typeNames: Record<string, string> = {};
 
   const isKnown = (flag: string) =>

--- a/graph/DirectedGraph.ts
+++ b/graph/DirectedGraph.ts
@@ -43,11 +43,11 @@ export class DirectedGraph<T> {
     }
   }
 
-  get vertices() {
+  get vertices(): Set<N<T>> {
     return new Set(this.#vertices);
   }
 
-  get edges() {
+  get edges(): Set<[N<T>, N<T>]> {
     const edges = new Set<[N<T>, N<T>]>();
 
     for (const [source, targets] of this.#edgesFrom) {
@@ -59,14 +59,14 @@ export class DirectedGraph<T> {
     return edges;
   }
 
-  get roots() {
+  get roots(): Set<N<T>> {
     return new Set(
       [...this.#vertices]
         .filter((vertex) => this.#edgesTo.get(vertex)!.size === 0),
     );
   }
 
-  get leaves() {
+  get leaves(): Set<N<T>> {
     return new Set(
       [...this.#vertices]
         .filter((vertex) => this.#edgesFrom.get(vertex)!.size === 0),
@@ -76,7 +76,7 @@ export class DirectedGraph<T> {
   /** Mutates `visited`, providing information about which nodes were visited.
    * When `false` is returned, the `visited` nodes can be safely removed from
    * further consideration. */
-  #hasCycle(vertex: N<T>, visited: Set<N<T>>) {
+  #hasCycle(vertex: N<T>, visited: Set<N<T>>): boolean {
     if (visited.has(vertex)) return true;
     visited.add(vertex);
 
@@ -93,7 +93,7 @@ export class DirectedGraph<T> {
     return this.#hasCycle(vertex, new Set());
   }
 
-  get isCyclic() {
+  get isCyclic(): boolean {
     const visited = new Set<N<T>>();
 
     for (const vertex of this) {
@@ -104,7 +104,7 @@ export class DirectedGraph<T> {
     return false;
   }
 
-  #isTree(root: N<T>) {
+  #isTree(root: N<T>): boolean {
     const visited = new Set<N<T>>();
     const stack = [root];
 
@@ -118,7 +118,7 @@ export class DirectedGraph<T> {
     return true;
   }
 
-  get isTree() {
+  get isTree(): boolean {
     const roots = this.roots;
     if (roots.size !== 1) return false;
     if (this.isCyclic) return false;
@@ -126,7 +126,7 @@ export class DirectedGraph<T> {
     return this.#isTree(roots.values().next().value);
   }
 
-  get isForest() {
+  get isForest(): boolean {
     if (this.isCyclic) return false;
 
     const roots: Set<N<T>> = new Set();
@@ -144,42 +144,42 @@ export class DirectedGraph<T> {
     return true;
   }
 
-  #assertVertex(vertex: N<T>) {
+  #assertVertex(vertex: N<T>): void {
     if (!this.#vertices.has(vertex)) throw new VertexError(vertex);
   }
 
-  has(vertex: N<T>) {
+  has(vertex: N<T>): boolean {
     return this.#vertices.has(vertex);
   }
 
   /** Returns all vertices that have an edge to the given vertex. */
-  edgesTo(target: N<T>) {
+  edgesTo(target: N<T>): Set<N<T>> {
     this.#assertVertex(target);
 
     return new Set(this.#edgesTo.get(target)!);
   }
 
   /** Returns all vertices that have an edge from the given vertex. */
-  edgesFrom(source: N<T>) {
+  edgesFrom(source: N<T>): Set<N<T>> {
     this.#assertVertex(source);
 
     return new Set(this.#edgesFrom.get(source)!);
   }
 
-  #addVertex(vertex: N<T>) {
+  #addVertex(vertex: N<T>): void {
     this.#vertices.add(vertex);
     !this.#edgesFrom.has(vertex) && this.#edgesFrom.set(vertex, new Set());
     !this.#edgesTo.has(vertex) && this.#edgesTo.set(vertex, new Set());
   }
 
-  #addEdge(source: N<T>, target: N<T>) {
+  #addEdge(source: N<T>, target: N<T>): void {
     this.#addVertex(source);
     this.#addVertex(target);
     this.#edgesFrom.get(source)!.add(target);
     this.#edgesTo.get(target)!.add(source);
   }
 
-  #addEdges(source: N<T>, targets: I<T>) {
+  #addEdges(source: N<T>, targets: I<T>): void {
     this.#addVertex(source);
     for (const target of targets) {
       this.#addVertex(target);
@@ -198,7 +198,7 @@ export class DirectedGraph<T> {
    * graph.add("d", ["e", "f"]); // add d, e, f, d -> e, d -> f
    */
   add(source: N<T>, targets: N<T> | I<T>): this;
-  add(source: N<T>, targets?: N<T> | I<T>) {
+  add(source: N<T>, targets?: N<T> | I<T>): this {
     targets === undefined
       ? this.#addVertex(source)
       : typeof targets === "object" && Symbol.iterator in targets
@@ -208,7 +208,7 @@ export class DirectedGraph<T> {
     return this;
   }
 
-  #removeVertex(vertex: N<T>) {
+  #removeVertex(vertex: N<T>): this {
     this.#assertVertex(vertex);
     this.#vertices.delete(vertex);
 
@@ -225,7 +225,7 @@ export class DirectedGraph<T> {
     return this;
   }
 
-  #removeEdge(source: N<T>, target: N<T>) {
+  #removeEdge(source: N<T>, target: N<T>): void {
     this.#assertVertex(source);
     this.#assertVertex(target);
 
@@ -233,7 +233,7 @@ export class DirectedGraph<T> {
     this.#edgesTo.get(target)!.delete(source);
   }
 
-  #removeEdges(source: N<T>, targets: I<T>) {
+  #removeEdges(source: N<T>, targets: I<T>): void {
     this.#assertVertex(source);
 
     for (const target of targets) {
@@ -253,7 +253,7 @@ export class DirectedGraph<T> {
    * graph.remove("a", "b"); // remove a -> b
    */
   remove(source: N<T>, targets: N<T> | I<T>): this;
-  remove(source: N<T>, targets?: N<T> | I<T>) {
+  remove(source: N<T>, targets?: N<T> | I<T>): this {
     targets === undefined
       ? this.#removeVertex(source)
       : typeof targets === "object" && Symbol.iterator in targets
@@ -367,7 +367,7 @@ export class DirectedGraph<T> {
     return subgraph;
   }
 
-  [Symbol.for("Deno.customInspect")]() {
+  [Symbol.for("Deno.customInspect")](): string {
     return `DirectedGraph(${this.#vertices.size} vertices, ${this.edges.size} edges)`;
   }
 

--- a/io/clipboard.ts
+++ b/io/clipboard.ts
@@ -1,5 +1,5 @@
 /** Only supports MacOS and Windows. */
-export async function copy(text: string) {
+export async function copy(text: string): Promise<void> {
   const os = Deno.build.os;
 
   let cmd: string;
@@ -27,7 +27,7 @@ export async function copy(text: string) {
 }
 
 /** Only supports MacOS and Windows. */
-export async function paste() {
+export async function paste(): Promise<string> {
   const os = Deno.build.os;
 
   let cmd: string;

--- a/md/codeBlock/create.ts
+++ b/md/codeBlock/create.ts
@@ -17,7 +17,7 @@ import { create as createIndented } from "./indented.ts";
 export function create(
   code: string,
   options: CreateFencedOptions = {},
-) {
+): string {
   const fenced = options.char || options.lang || options.meta;
 
   return fenced ? createFenced(code, options) : createIndented(code);

--- a/md/codeBlock/eval.ts
+++ b/md/codeBlock/eval.ts
@@ -32,7 +32,7 @@ export type EvaluateOptions = {
 function _getCode(
   details: CodeBlockDetails,
   replace: Exclude<EvaluateOptions["replace"], undefined>,
-) {
+): string {
   if (details.type === "indented") throw new IndentedCodeBlockError();
 
   const { lang, code } = details;
@@ -51,7 +51,7 @@ function _getCode(
 export async function evaluate(
   codeBlock: string,
   { replace = [] }: EvaluateOptions = {},
-) {
+): Promise<CmdResult> {
   const details = parseCodeBlock(codeBlock);
   const code = _getCode(details, replace);
 
@@ -63,7 +63,12 @@ export async function evaluate(
 export async function evaluateAll(
   markdown: string,
   { replace = [] }: EvaluateOptions = {},
-) {
+): Promise<
+  Map<
+    CodeBlockDetails,
+    IndentedCodeBlockError | NoLanguageError | UnknownLanguageError | CmdResult
+  >
+> {
   const results: Map<
     CodeBlockDetails,
     | CmdResult

--- a/md/codeBlock/fenced.ts
+++ b/md/codeBlock/fenced.ts
@@ -37,7 +37,7 @@ export type CreateFencedOptions = infoString.Info & {
 export function create(
   code: string,
   { char = "`", ...info }: CreateFencedOptions = {},
-) {
+): string {
   const _infoString = infoString.stringify(info);
   _infoString.includes("`") && (char = "~");
 

--- a/md/codeBlock/indented.ts
+++ b/md/codeBlock/indented.ts
@@ -7,7 +7,7 @@ export type IndentedCodeBlockDetails = {
   indentation: string;
 };
 
-export function create(code: string) {
+export function create(code: string): string {
   return indent(code, 4);
 }
 

--- a/md/codeBlock/infoString.ts
+++ b/md/codeBlock/infoString.ts
@@ -36,7 +36,7 @@ export type Info = {
 };
 
 /* See https://spec.commonmark.org/0.30/#info-string */
-export function stringify({ lang, meta }: Info = {}) {
+export function stringify({ lang, meta }: Info = {}): string {
   if (meta?.includes("\n")) throw new InfoStringError(meta);
   if (lang && /\s/.test(lang)) throw new LanguageError(lang);
 

--- a/md/script/evalCodeBlocks.ts
+++ b/md/script/evalCodeBlocks.ts
@@ -9,7 +9,7 @@ import {
 export async function evalCodeBlocks(
   filePath: string,
   replace?: EvaluateOptions["replace"],
-) {
+): Promise<void> {
   const markdown = await Deno.readTextFile(filePath);
   console.log(`Executing code blocks in ${filePath}`);
 

--- a/object/setNestedEntry.ts
+++ b/object/setNestedEntry.ts
@@ -19,7 +19,7 @@ export function setNestedEntry<
   keys: Array<string | number | symbol>,
   // deno-lint-ignore no-explicit-any
   val: any,
-) {
+): T {
   const key = keys.shift() as keyof T;
 
   if (!(key in obj)) obj[key] = {} as T[keyof T];

--- a/path/globRoot.ts
+++ b/path/globRoot.ts
@@ -7,7 +7,7 @@ import { isGlob } from "../_deps/path.ts";
  * globRoot("C:\\\\foo\\bar\\*.ts") // "C:\\\\foo\\bar\\"
  * globRoot("foo/bar") // "foo/bar"
  */
-export function globRoot(glob: string) {
+export function globRoot(glob: string): string {
   let root = "";
 
   const parts = glob.split(/([\/\\])/);

--- a/string/dedent.ts
+++ b/string/dedent.ts
@@ -12,7 +12,7 @@ export function dedent(
 export function dedent(
   str: string,
   { char = " ", returnIndentation = false } = {},
-) {
+): string | [code: string, indentation: string] {
   if (str.length === 0) return returnIndentation ? ["", ""] : "";
 
   if (char.length !== 1) throw new Error("char must be a single character");

--- a/string/indent.ts
+++ b/string/indent.ts
@@ -1,4 +1,4 @@
-export function indent(str: string, indent: string | number) {
+export function indent(str: string, indent: string | number): string {
   indent = typeof indent === "number" ? " ".repeat(indent) : indent;
   let indented = "";
   const lines = str.split("\n");

--- a/string/sequence.ts
+++ b/string/sequence.ts
@@ -6,7 +6,7 @@
 export function sequences(
   target: string | RegExp,
   str: string,
-) {
+): string[] {
   if (!target || !str) return [];
 
   const pattern = typeof target === "string" ? target : target.source;
@@ -22,7 +22,7 @@ export function sequences(
 export function mostConsecutive(
   target: string,
   str: string,
-) {
+): number {
   if (!target || !str) return 0;
 
   const matches = str.match(new RegExp(`(${target})+`, "g"));

--- a/ts/evaluate.ts
+++ b/ts/evaluate.ts
@@ -1,4 +1,4 @@
-import { cmd, CmdOptions } from "../cli/cmd.ts";
+import { cmd, CmdOptions, CmdResult } from "../cli/cmd.ts";
 
 export type EvaluateTypeScriptOptions = Pick<CmdOptions, "cwd" | "env"> & {
   typeCheck?: boolean;
@@ -6,7 +6,10 @@ export type EvaluateTypeScriptOptions = Pick<CmdOptions, "cwd" | "env"> & {
 
 /** Evaluates TypeScript code using `deno eval`, returning the full `CmdResult`.
  * Type checking is enabled by default. */
-export async function evaluate(code: string, opts?: EvaluateTypeScriptOptions) {
+export async function evaluate(
+  code: string,
+  opts?: EvaluateTypeScriptOptions,
+): Promise<CmdResult> {
   const { typeCheck = true, cwd, env } = opts ?? {};
 
   const command = typeCheck


### PR DESCRIPTION
## Refactors

* (types): require explicit return types (98a780f)

  Because Handy is a library rather than an application, explicit return types help us understand when we might accidentally break an existing API. I've gone back and forth on this, but [this video](https://www.youtube.com/watch?v=nwSe95uFN8E) from esteemed TypeScript wizard @mattpocock pushed me over the edge.

  Unfortunately Deno's linter has very few linting rules and no per-rule configurations, so our only option is to enable this rule for all functions even ones in test files and functions that aren't exported. Hopefully in the future we'll be able to apply this only to exported functions.

* (DirectedGraph): add `Vertex`, `Vertices`, and `Edge` types (10dab15)

## Documentation

* (fs/globImport): codify `ImportLike`; refactor JSDocs (e836e4b)