### PR TITLE
refactor(constants): move `_constants.ts` -> `_test/constants.ts`

### DIFF
--- a/_constants.ts
+++ b/_constants.ts
@@ -1,4 +1,0 @@
-import { resolve } from "./_deps/path.ts";
-import { dir } from "./path/dir.ts";
-
-export const FIXTURE_DIR = resolve(dir(import.meta), "_test", "fixture");

--- a/_test/constants.ts
+++ b/_test/constants.ts
@@ -1,0 +1,4 @@
+import { resolve } from "../_deps/path.ts";
+import { dir } from "../path/dir.ts";
+
+export const FIXTURE_DIR = resolve(dir(import.meta), "fixture");

--- a/fs/findNearestFile.test.ts
+++ b/fs/findNearestFile.test.ts
@@ -1,6 +1,6 @@
 import { resolve } from "../_deps/path.ts";
 import { assertEquals, assertRejects, describe, it } from "../_deps/testing.ts";
-import { FIXTURE_DIR } from "../_constants.ts";
+import { FIXTURE_DIR } from "../_test/constants.ts";
 import { findNearestFile } from "./findNearestFile.ts";
 
 const A_DIR = resolve(FIXTURE_DIR, "fs", "a");

--- a/fs/glob.test.ts
+++ b/fs/glob.test.ts
@@ -1,7 +1,7 @@
 import { resolve } from "../_deps/path.ts";
 import { assertArrayIncludes, describe, it } from "../_deps/testing.ts";
 import { glob } from "./glob.ts";
-import { FIXTURE_DIR } from "../_constants.ts";
+import { FIXTURE_DIR } from "../_test/constants.ts";
 
 const GLOB = resolve(FIXTURE_DIR, "fs", "**", "*.ts");
 

--- a/fs/globImport.test.ts
+++ b/fs/globImport.test.ts
@@ -8,7 +8,7 @@ import {
   it,
 } from "../_deps/testing.ts";
 import { FileHandlerError, globImport } from "./globImport.ts";
-import { FIXTURE_DIR } from "../_constants.ts";
+import { FIXTURE_DIR } from "../_test/constants.ts";
 import { posixNewlines } from "../os/newlines.ts";
 
 const globPattern = resolve(FIXTURE_DIR, "fs", "**", "*.ts");


### PR DESCRIPTION
I realized that the constants file is only for tests and so should be moved into the `_test` directory to signify that and to declutter the repo root.

This PR led to many insights which I spun off into #54, #55. Now that they've merged, this PR is appropriately small and focused 👏 