### PR TITLE
feat(os): init; add `newlines` utilities

### DIFF
--- a/os/mod.ts
+++ b/os/mod.ts
@@ -1,0 +1,1 @@
+export * from "./utils.ts";

--- a/os/newlines.test.ts
+++ b/os/newlines.test.ts
@@ -1,0 +1,33 @@
+import { assertEquals, describe, it } from "../_deps/testing.ts";
+import { macNewlines, posixNewlines, windowsNewlines } from "./newlines.ts";
+
+describe("macNewlines", () => {
+  it("replaces \\n", () => assertEquals(macNewlines("foo\nbar"), "foo\rbar"));
+
+  it("replaces \\r\\n", () =>
+    assertEquals(macNewlines("foo\r\nbar"), "foo\rbar"));
+
+  it("ignores existing \\r", () =>
+    assertEquals(macNewlines("foo\rbar"), "foo\rbar"));
+});
+
+describe("posixNewlines", () => {
+  it("replaces \\r", () => assertEquals(posixNewlines("foo\rbar"), "foo\nbar"));
+
+  it("replaces \\r\\n", () =>
+    assertEquals(posixNewlines("foo\r\nbar"), "foo\nbar"));
+
+  it("ignores existing \\n", () =>
+    assertEquals(posixNewlines("foo\nbar"), "foo\nbar"));
+});
+
+describe("windowsNewlines", () => {
+  it("replaces \\r", () =>
+    assertEquals(windowsNewlines("foo\rbar"), "foo\r\nbar"));
+
+  it("replaces \\n", () =>
+    assertEquals(windowsNewlines("foo\nbar"), "foo\r\nbar"));
+
+  it("ignores existing \\r\\n", () =>
+    assertEquals(windowsNewlines("foo\r\nbar"), "foo\r\nbar"));
+});

--- a/os/newlines.ts
+++ b/os/newlines.ts
@@ -1,0 +1,14 @@
+/** Replace all `\r\n` and `\n` with `\r`. Handles existing `\r` correctly. */
+export function macNewlines(str: string): string {
+  return str.replace(/\r?\n/g, "\r");
+}
+
+/** Replace all `\r\n` and `\r` with `\n`. Handles existing `\n` correctly. */
+export function posixNewlines(str: string): string {
+  return str.replace(/\r\n?/g, "\n");
+}
+
+/** Replace all `\r` and `\n` with `\r\n`. Handles existing `\r\n` correctly. */
+export function windowsNewlines(str: string): string {
+  return str.replace(/(\r)\n?|\r?(\n)/g, "\r\n");
+}

--- a/os/utils.ts
+++ b/os/utils.ts
@@ -1,0 +1,1 @@
+export * from "./newlines.ts";

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ Utility functions, classes, types, and scripts in uncompiled TS, for Deno.
 - [`md`](#md)
   - [`script/evalCodeBlocks`](#scriptevalcodeblocks)
 - [`object`](#object)
+- [`os`](#os)
 - [`path`](#path)
 - [`string`](#string)
 - [`ts`](#ts)
@@ -198,6 +199,16 @@ import { setNestedEntry } from "https://deno.land/x/handy/object/utils.ts";
 
 const S = Symbol("symbol");
 setNestedEntry({}, ["a", 10, S], "👋"); // { a: { 10: { [S]: "👋" } } }
+```
+
+## `os`
+
+OS-related utilities.
+
+```ts
+import { posixNewlines } from "https://deno.land/x/handy/os/utils.ts";
+
+posixNewlines("A\r\nB\rC"); // "A\nB\nC"
 ```
 
 ## `path`


### PR DESCRIPTION
Tiny helpers inspired by the work done to test `globImport` on windows.