### PR TITLE
`DirectedGraph` enhancements

### DIFF
--- a/graph/DirectedGraph.test.ts
+++ b/graph/DirectedGraph.test.ts
@@ -33,6 +33,9 @@ describe("DirectedGraph", () => {
 
   describe("namespace", () => {
     it("includes its related types", () => {
+      const _vertex: DirectedGraph.Vertex<string> = "a";
+      const _vertices: DirectedGraph.Vertices<string> = new Set("a");
+      const _edge: DirectedGraph.Edge<string> = ["a", "b"];
       const _path: DirectedGraph.Path<string> = ["a", "b", "c"];
       const _visitor: DirectedGraph.Visitor<string, void> = () => {};
       const _options: DirectedGraph.WalkOptions = { includeSource: true };

--- a/graph/DirectedGraph.test.ts
+++ b/graph/DirectedGraph.test.ts
@@ -13,6 +13,20 @@ import { VertexError } from "./errors.ts";
 describe("DirectedGraph", () => {
   let graph: DirectedGraph<string>;
 
+  function assertVertices(
+    graph: DirectedGraph<string>,
+    ...vertices: string[]
+  ): void {
+    assertEquals(graph.vertices, new Set(vertices));
+  }
+
+  function assertEdges(
+    graph: DirectedGraph<string>,
+    ...edges: [string, string][]
+  ): void {
+    assertEquals(graph.edges, new Set(edges));
+  }
+
   beforeEach(() => {
     graph = new DirectedGraph();
   });
@@ -29,16 +43,18 @@ describe("DirectedGraph", () => {
     it("can clone a graph", () => {
       graph.add(["a", "b"]);
       const clone = new DirectedGraph(graph);
-      assert(clone.has("a", "b"));
-      assert(clone.edgesFrom("a").has("b"));
-      assert(clone.edgesTo("b").has("a"));
+      assertVertices(clone, "a", "b");
+      assertEdges(clone, ["a", "b"]);
 
       clone.remove("a");
-      assert(graph.has("a"));
-      assert(!clone.has("a"));
+      assertVertices(graph, "a", "b");
+      assertVertices(clone, "b");
 
       clone.add(["c", "d"]);
-      assert(!graph.has("c", "d"));
+      assertVertices(graph, "a", "b");
+      assertEdges(graph, ["a", "b"]);
+      assertVertices(clone, "b", "c", "d");
+      assertEdges(clone, ["c", "d"]);
     });
   });
 
@@ -134,14 +150,14 @@ describe("DirectedGraph", () => {
 
     it("adds edges", () => {
       graph.add(["a", "b"], ["a", "c"]);
-      assertEquals(graph.vertices, new Set(["a", "b", "c"]));
-      assertEquals(graph.edges, new Set([["a", "b"], ["a", "c"]]));
+      assertVertices(graph, "a", "b", "c");
+      assertEdges(graph, ["a", "b"], ["a", "c"]);
     });
 
     it("deduplicates edges", () => {
       graph.add(["a", "b"], ["a", "b"]);
-      assertEquals(graph.vertices, new Set(["a", "b"]));
-      assertEquals(graph.edges, new Set([["a", "b"]]));
+      assertVertices(graph, "a", "b");
+      assertEdges(graph, ["a", "b"]);
     });
 
     it("adds paths", () => {
@@ -171,14 +187,14 @@ describe("DirectedGraph", () => {
 
     it("removes edges", () => {
       graph.add(["a", "b"]).remove(["a", "b"]);
-      assertEquals(graph.vertices, new Set(["a", "b"]));
-      assertEquals(graph.edges, new Set());
+      assertVertices(graph, "a", "b");
+      assertEdges(graph);
     });
 
     it("removes paths", () => {
       graph.add(["a", "b", "c", "d", "e"]).remove(["b", "c", "d"]);
-      assertEquals(graph.vertices, new Set(["a", "b", "c", "d", "e"]));
-      assertEquals(graph.edges, new Set([["a", "b"], ["d", "e"]]));
+      assertVertices(graph, "a", "b", "c", "d", "e");
+      assertEdges(graph, ["a", "b"], ["d", "e"]);
     });
 
     it("ignores single-element paths", () => {
@@ -189,16 +205,14 @@ describe("DirectedGraph", () => {
 
     it("removes mixed inputs", () => {
       graph.add(["a", "b", "c", "d", "e"], "f").remove(["a", "b", "c"], "e");
-      assertEquals(graph.vertices, new Set(["a", "b", "c", "d", "f"]));
-      assertEquals(graph.edges, new Set([["c", "d"]]));
+      assertVertices(graph, "a", "b", "c", "d", "f");
+      assertEdges(graph, ["c", "d"]);
     });
 
     it("removes edges of a removed vertex", () => {
       graph.add(["a", "b"], ["a", "c"]).remove("a");
-      assert(!graph.has("a"));
-      assert(graph.has("b", "c"));
-      assert(!graph.edgesTo("b").has("a"));
-      assert(!graph.edgesTo("c").has("a"));
+      assertVertices(graph, "b", "c");
+      assertEdges(graph);
     });
   });
 
@@ -322,16 +336,16 @@ describe("DirectedGraph", () => {
   it("creates subgraphs", () => {
     graph.add(["a", "b", "c", "d"]);
     const subgraph = graph.subgraph(["a", "b", "c"]);
-    assertEquals(subgraph.vertices, new Set(["a", "b", "c"]));
-    assertEquals(subgraph.edges, new Set([["a", "b"], ["b", "c"]]));
+    assertVertices(subgraph, "a", "b", "c");
+    assertEdges(subgraph, ["a", "b"], ["b", "c"]);
 
     const subgraph2 = graph.subgraph(["a", "b", "c", "d"]);
-    assertEquals(subgraph2.vertices, graph.vertices);
-    assertEquals(subgraph2.edges, graph.edges);
+    assertVertices(subgraph2, ...graph.vertices);
+    assertEdges(subgraph2, ...graph.edges);
 
     const subgraph3 = graph.subgraph(["b", "d"]);
-    assertEquals(subgraph3.vertices, new Set(["b", "d"]));
-    assertEquals(subgraph3.edges, new Set([]));
+    assertVertices(subgraph3, "b", "d");
+    assertEdges(subgraph3);
   });
 
   describe("integration: collection.smallest", () => {

--- a/graph/DirectedGraph.test.ts
+++ b/graph/DirectedGraph.test.ts
@@ -27,7 +27,7 @@ describe("DirectedGraph", () => {
 
   describe("constructor", () => {
     it("can clone a graph", () => {
-      graph.add("a", "b");
+      graph.add(["a", "b"]);
       const clone = new DirectedGraph(graph);
       assert(clone.has("a", "b"));
       assert(clone.edgesFrom("a").has("b"));
@@ -37,7 +37,7 @@ describe("DirectedGraph", () => {
       assert(graph.has("a"));
       assert(!clone.has("a"));
 
-      clone.add("c", "d");
+      clone.add(["c", "d"]);
       assert(!graph.has("c", "d"));
     });
   });
@@ -48,54 +48,51 @@ describe("DirectedGraph", () => {
     it("has edges", () => assert(graph.edges instanceof Set));
 
     it("has root vertices", () => {
-      graph.add("a", "b").add("b", "c").add("c", "d");
+      graph.add(["a", "b", "c", "d"]);
       assertEquals(graph.roots, new Set("a"));
     });
 
     it("has leaf vertices", () => {
-      graph.add("a", "b").add("b", "c").add("c", "d");
+      graph.add(["a", "b", "c", "d"]);
       assertEquals(graph.leaves, new Set(["d"]));
     });
 
     it("can tell if it's cyclic", () => {
-      graph.add("a", "b").add("b", "c").add("c", "d");
+      graph.add(["a", "b", "c", "d"]);
       assert(!graph.isCyclic);
 
-      assert(new DirectedGraph(graph).add("d", "a").isCyclic);
-      assert(new DirectedGraph(graph).add("d", "c").isCyclic);
-      assert(new DirectedGraph(graph).add("d", "b").isCyclic);
-      assert(new DirectedGraph<string>().add("y", "z").add("z", "y").isCyclic);
-      assert(!new DirectedGraph(graph).add("a", "c").isCyclic);
+      assert(new DirectedGraph(graph).add(["d", "a"]).isCyclic);
+      assert(new DirectedGraph(graph).add(["d", "c"]).isCyclic);
+      assert(new DirectedGraph(graph).add(["d", "b"]).isCyclic);
+      assert(new DirectedGraph<string>().add(["y", "z", "y"]).isCyclic);
+      assert(!new DirectedGraph(graph).add(["a", "c"]).isCyclic);
     });
 
     it("can tell if it's a tree", () => {
-      graph.add("a", "b").add("b", "c").add("c", "d");
-      graph.add("a", "e").add("b", "f");
+      graph.add(["a", "b", "c", "d"], ["a", "e"], ["b", "f"]);
       assert(graph.isTree);
 
-      assert(!new DirectedGraph(graph).add("d", "a").isTree);
-      assert(!new DirectedGraph(graph).add("a", "c").isTree);
-      assert(!new DirectedGraph(graph).add("y", "z").add("z", "y").isTree);
+      assert(!new DirectedGraph(graph).add(["d", "a"]).isTree);
+      assert(!new DirectedGraph(graph).add(["a", "c"]).isTree);
+      assert(!new DirectedGraph(graph).add(["y", "z", "y"]).isTree);
     });
 
     it("can tell if it's a forest", () => {
-      graph.add("a", "b").add("b", "c").add("c", "d");
-      graph.add("h", "i");
-      graph.add("v", "w").add("w", "x");
+      graph.add(["a", "b", "c", "d"], ["h", "i"], ["v", "w", "x"]);
       assert(graph.isForest);
 
-      assert(!new DirectedGraph(graph).add("b", "i").isForest);
-      assert(new DirectedGraph(graph).add("x", "h").isForest);
-      assert(new DirectedGraph(graph).add("d", "v").isForest);
+      assert(!new DirectedGraph(graph).add(["b", "i"]).isForest);
+      assert(new DirectedGraph(graph).add(["x", "h"]).isForest);
+      assert(new DirectedGraph(graph).add(["d", "v"]).isForest);
     });
 
     it("has custom console.log output", () => {
-      graph.add("a", "b").add("b", "c").add("c", "d");
+      graph.add(["a", "b", "c", "d"]);
       assertEquals(Deno.inspect(graph), "DirectedGraph(4 vertices, 3 edges)");
     });
 
     it("is iterable, yielding vertices", () => {
-      graph.add("a", "b").add("b", "c").add("c", "d");
+      graph.add(["a", "b", "c", "d"]);
       assertEquals([...graph], ["a", "b", "c", "d"]);
     });
   });
@@ -111,15 +108,12 @@ describe("DirectedGraph", () => {
 
     it("accepts an edge", () => {
       assert(!graph.has(["a", "b"]));
-      assert(graph.add("a", "b").has(["a", "b"]));
+      assert(graph.add(["a", "b"]).has(["a", "b"]));
     });
 
     it("accepts a path", () => {
       assert(!graph.has(["a", "b", "c", "d"]));
-      assert(
-        graph.add("a", "b").add("b", "c").add("c", "d")
-          .has(["a", "b", "c", "d"]),
-      );
+      assert(graph.add(["a", "b", "c", "d"]).has(["a", "b", "c", "d"]));
     });
 
     it("treats a single-element path as a vertex", () => {
@@ -129,36 +123,44 @@ describe("DirectedGraph", () => {
     it("accepts multiple inputs", () => {
       assert(!graph.has(["a", "b"], "c", ["d", "e", "f"]));
       assert(
-        graph.add("a", "b").add("c").add("d", "e").add("e", "f")
+        graph.add(["a", "b"], "c", ["d", "e", "f"])
           .has(["a", "b"], "c", ["d", "e", "f"]),
       );
     });
   });
 
-  it("adds vertices", () => {
-    assert(!graph.has("a"));
-    assert(graph.add("a").has("a"));
-  });
+  describe("graph.add()", () => {
+    it("adds vertices", () => assert(graph.add("a").has("a")));
 
-  it("adds edges", () => {
-    assert(!graph.has("a", "b"));
+    it("adds edges", () => {
+      graph.add(["a", "b"], ["a", "c"]);
+      assertEquals(graph.vertices, new Set(["a", "b", "c"]));
+      assertEquals(graph.edges, new Set([["a", "b"], ["a", "c"]]));
+    });
 
-    graph.add("a", "b").add("a", "c");
-    assert(graph.has("a", "b", "c"));
-    assert(graph.edgesFrom("a").has("b"));
-    assert(graph.edgesFrom("a").has("c"));
-    assert(graph.edgesFrom("a").size === 2);
-    assert(graph.edgesTo("b").has("a"));
-    assert(graph.edgesTo("b").size === 1);
-    assert(graph.edgesTo("c").has("a"));
-    assert(graph.edgesTo("c").size === 1);
-  });
+    it("deduplicates edges", () => {
+      graph.add(["a", "b"], ["a", "b"]);
+      assertEquals(graph.vertices, new Set(["a", "b"]));
+      assertEquals(graph.edges, new Set([["a", "b"]]));
+    });
 
-  it("deduplicates edges", () => {
-    graph.add("a", "b").add("a", "b");
-    assert(graph.edges.size === 1);
-    assert(graph.edgesFrom("a").size === 1);
-    assert(graph.edgesTo("b").size === 1);
+    it("adds paths", () => {
+      graph.add(["a", "b", "c"]);
+      assertVertices(graph, "a", "b", "c");
+      assertEdges(graph, ["a", "b"], ["b", "c"]);
+    });
+
+    it("treats a single-element path as a vertex", () => {
+      graph.add(["a"]);
+      assertVertices(graph, "a");
+      assertEdges(graph);
+    });
+
+    it("handles multiple inputs", () => {
+      graph.add(["a", "b"], "c", ["d", "e", "f"]);
+      assertVertices(graph, "a", "b", "c", "d", "e", "f");
+      assertEdges(graph, ["a", "b"], ["d", "e"], ["e", "f"]);
+    });
   });
 
   it("removes vertices", () => {
@@ -167,14 +169,14 @@ describe("DirectedGraph", () => {
   });
 
   it("removes edges", () => {
-    graph.add("a", "b").remove("a", "b");
+    graph.add(["a", "b"]).remove("a", "b");
     assert(graph.has("a", "b"));
     assert(!graph.edgesFrom("a").has("b"));
     assert(!graph.edgesTo("b").has("a"));
   });
 
   it("removes edges of a removed vertex", () => {
-    graph.add("a", "b").add("a", "c").remove("a");
+    graph.add(["a", "b"], ["a", "c"]).remove("a");
     assert(!graph.has("a"));
     assert(graph.has("b", "c"));
     assert(!graph.edgesTo("b").has("a"));
@@ -182,7 +184,7 @@ describe("DirectedGraph", () => {
   });
 
   it("returns new vertices and edges", () => {
-    const vertices = graph.add("a", "b").vertices;
+    const vertices = graph.add(["a", "b"]).vertices;
     vertices.delete("a");
     assert(graph.has("a"));
     assert(!vertices.has("a"));
@@ -204,21 +206,21 @@ describe("DirectedGraph", () => {
 
   describe("graph.walk", () => {
     it("traverses depth-first", () => {
-      graph.add("a", ["b", "c", "d"]).add("b", ["e", "f"]);
+      graph.add(["a", "b", "e"], ["a", "c"], ["a", "d"], ["b", "f"]);
       const visited: string[] = [];
       graph.walk("a", (vertex) => void visited.push(vertex));
       assertEquals(visited, ["b", "e", "f", "c", "d"]);
     });
 
     it("can walk in reverse", () => {
-      graph.add("a", "z").add("b", "z").add("c", "z");
+      graph.add(["a", "z"], ["b", "z"], ["c", "z"]);
       const visited: string[] = [];
       graph.walk("z", (vertex) => void visited.push(vertex), { reverse: true });
       assertEquals(visited, ["a", "b", "c"]);
     });
 
     it("can return a value", () => {
-      graph.add("a", ["b", "c", "d"]);
+      graph.add(["a", "b"], ["a", "c"], ["a", "d"]);
       const visited: string[] = [];
       const result = graph
         .walk("a", (v) => v === "c" ? "stopped at c!" : void visited.push(v));
@@ -227,7 +229,7 @@ describe("DirectedGraph", () => {
     });
 
     it("can visit the source vertex", () => {
-      graph.add("a", ["b", "c", "d"]);
+      graph.add(["a", "b"], ["a", "c"], ["a", "d"]);
       const visited: string[] = [];
       graph.walk(
         "a",
@@ -238,21 +240,21 @@ describe("DirectedGraph", () => {
     });
 
     it("can traverse breadth-first", () => {
-      graph.add("a", ["b", "c", "d"]).add("b", ["e", "f"]);
+      graph.add(["a", "b", "e"], ["a", "c"], ["a", "d"], ["b", "f"]);
       const visited: string[] = [];
       graph.walk("a", (v) => void visited.push(v), { breadthFirst: true });
       assertEquals(visited, ["b", "c", "d", "e", "f"]);
     });
 
     it("skips visited vertices", () => {
-      graph.add("a", "b").add("b", "a");
+      graph.add(["a", "b", "a"]);
       const visited: string[] = [];
       graph.walk("a", (v) => void visited.push(v));
       assertEquals(visited, ["b"]);
     });
 
     it("can revisit vertices", () => {
-      graph.add("a", "b").add("b", "a");
+      graph.add(["a", "b", "a"]);
       const visited: string[] = [];
       graph.walk(
         "a",
@@ -272,12 +274,12 @@ describe("DirectedGraph", () => {
   });
 
   it("finds paths between vertices", () => {
-    graph.add("a", "b").add("b", "c").add("c", "d");
+    graph.add(["a", "b", "c", "d"]);
     assertEquals(graph.paths("a", "b"), [["a", "b"]]);
     assertEquals(graph.paths("a", "c"), [["a", "b", "c"]]);
     assertEquals(graph.paths("a", "d"), [["a", "b", "c", "d"]]);
 
-    graph.add("a", "c");
+    graph.add(["a", "c"]);
     assertEquals(graph.paths("a", "b"), [["a", "b"]]);
     assertEquals(graph.paths("a", "c"), [["a", "b", "c"], ["a", "c"]]);
     assertEquals(graph.paths("a", "d"), [
@@ -287,19 +289,19 @@ describe("DirectedGraph", () => {
   });
 
   it("identifies if a vertex has cycles", () => {
-    graph.add("a", "b").add("b", "c");
+    graph.add(["a", "b", "c"]);
     assert(!graph.hasCycle("a"));
     assert(!graph.hasCycle("b"));
     assert(!graph.hasCycle("c"));
 
-    graph.add("c", "a");
+    graph.add(["c", "a"]);
     assert(graph.hasCycle("a"));
     assert(graph.hasCycle("b"));
     assert(graph.hasCycle("c"));
   });
 
   it("creates subgraphs", () => {
-    graph.add("a", "b").add("b", "c").add("c", "d");
+    graph.add(["a", "b", "c", "d"]);
     const subgraph = graph.subgraph(["a", "b", "c"]);
     assertEquals(subgraph.vertices, new Set(["a", "b", "c"]));
     assertEquals(subgraph.edges, new Set([["a", "b"], ["b", "c"]]));
@@ -319,17 +321,17 @@ describe("DirectedGraph", () => {
       const graph = new DirectedGraph<T>();
       const sm = (a: T, b: T) => smallest(graph.paths(a, b));
 
-      graph.add("a", "b").add("b", "c").add("c", "d");
+      graph.add(["a", "b", "c", "d"]);
       assertEquals(sm("a", "b"), [["a", "b"]]);
       assertEquals(sm("a", "c"), [["a", "b", "c"]]);
       assertEquals(sm("a", "d"), [["a", "b", "c", "d"]]);
 
-      graph.add("a", "c");
+      graph.add(["a", "c"]);
       assertEquals(sm("a", "b"), [["a", "b"]]);
       assertEquals(sm("a", "c"), [["a", "c"]]);
       assertEquals(sm("a", "d"), [["a", "c", "d"]]);
 
-      graph.add("b", "d");
+      graph.add(["b", "d"]);
       assertEquals(sm("a", "b"), [["a", "b"]]);
       assertEquals(sm("a", "c"), [["a", "c"]]);
       assertEquals(sm("a", "d"), [["a", "b", "d"], ["a", "c", "d"]]);

--- a/graph/DirectedGraph.test.ts
+++ b/graph/DirectedGraph.test.ts
@@ -66,7 +66,7 @@ describe("DirectedGraph", () => {
       assert(new DirectedGraph(graph).add("d", "a").isCyclic);
       assert(new DirectedGraph(graph).add("d", "c").isCyclic);
       assert(new DirectedGraph(graph).add("d", "b").isCyclic);
-      assert(new DirectedGraph().add("y", "z").add("z", "y").isCyclic);
+      assert(new DirectedGraph<string>().add("y", "z").add("z", "y").isCyclic);
       assert(!new DirectedGraph(graph).add("a", "c").isCyclic);
     });
 

--- a/graph/DirectedGraph.test.ts
+++ b/graph/DirectedGraph.test.ts
@@ -163,24 +163,43 @@ describe("DirectedGraph", () => {
     });
   });
 
-  it("removes vertices", () => {
-    assert(graph.add("a").has("a"));
-    assert(!graph.remove("a").has("a"));
-  });
+  describe("graph.remove()", () => {
+    it("removes vertices", () => {
+      assert(graph.add("a").has("a"));
+      assert(!graph.remove("a").has("a"));
+    });
 
-  it("removes edges", () => {
-    graph.add(["a", "b"]).remove("a", "b");
-    assert(graph.has("a", "b"));
-    assert(!graph.edgesFrom("a").has("b"));
-    assert(!graph.edgesTo("b").has("a"));
-  });
+    it("removes edges", () => {
+      graph.add(["a", "b"]).remove(["a", "b"]);
+      assertEquals(graph.vertices, new Set(["a", "b"]));
+      assertEquals(graph.edges, new Set());
+    });
 
-  it("removes edges of a removed vertex", () => {
-    graph.add(["a", "b"], ["a", "c"]).remove("a");
-    assert(!graph.has("a"));
-    assert(graph.has("b", "c"));
-    assert(!graph.edgesTo("b").has("a"));
-    assert(!graph.edgesTo("c").has("a"));
+    it("removes paths", () => {
+      graph.add(["a", "b", "c", "d", "e"]).remove(["b", "c", "d"]);
+      assertEquals(graph.vertices, new Set(["a", "b", "c", "d", "e"]));
+      assertEquals(graph.edges, new Set([["a", "b"], ["d", "e"]]));
+    });
+
+    it("ignores single-element paths", () => {
+      graph.add(["a", "b", "c"]).remove(["b"]);
+      assertVertices(graph, "a", "b", "c");
+      assertEdges(graph, ["a", "b"], ["b", "c"]);
+    });
+
+    it("removes mixed inputs", () => {
+      graph.add(["a", "b", "c", "d", "e"], "f").remove(["a", "b", "c"], "e");
+      assertEquals(graph.vertices, new Set(["a", "b", "c", "d", "f"]));
+      assertEquals(graph.edges, new Set([["c", "d"]]));
+    });
+
+    it("removes edges of a removed vertex", () => {
+      graph.add(["a", "b"], ["a", "c"]).remove("a");
+      assert(!graph.has("a"));
+      assert(graph.has("b", "c"));
+      assert(!graph.edgesTo("b").has("a"));
+      assert(!graph.edgesTo("c").has("a"));
+    });
   });
 
   it("returns new vertices and edges", () => {

--- a/graph/DirectedGraph.test.ts
+++ b/graph/DirectedGraph.test.ts
@@ -29,8 +29,7 @@ describe("DirectedGraph", () => {
     it("can clone a graph", () => {
       graph.add("a", "b");
       const clone = new DirectedGraph(graph);
-      assert(clone.has("a"));
-      assert(clone.has("b"));
+      assert(clone.has("a", "b"));
       assert(clone.edgesFrom("a").has("b"));
       assert(clone.edgesTo("b").has("a"));
 
@@ -39,8 +38,7 @@ describe("DirectedGraph", () => {
       assert(!clone.has("a"));
 
       clone.add("c", "d");
-      assert(!graph.has("c"));
-      assert(!graph.has("d"));
+      assert(!graph.has("c", "d"));
     });
   });
 
@@ -105,9 +103,36 @@ describe("DirectedGraph", () => {
   it("has chainable add/remove methods", () =>
     assert(graph.add("a").remove("a") === graph));
 
-  it("tells if it has a vertex", () => {
-    assert(!graph.has("a"));
-    assert(graph.add("a").has("a"));
+  describe("graph.has()", () => {
+    it("accepts a vertex", () => {
+      assert(!graph.has("a"));
+      assert(graph.add("a").has("a"));
+    });
+
+    it("accepts an edge", () => {
+      assert(!graph.has(["a", "b"]));
+      assert(graph.add("a", "b").has(["a", "b"]));
+    });
+
+    it("accepts a path", () => {
+      assert(!graph.has(["a", "b", "c", "d"]));
+      assert(
+        graph.add("a", "b").add("b", "c").add("c", "d")
+          .has(["a", "b", "c", "d"]),
+      );
+    });
+
+    it("treats a single-element path as a vertex", () => {
+      assert(graph.add("a").has(["a"]));
+    });
+
+    it("accepts multiple inputs", () => {
+      assert(!graph.has(["a", "b"], "c", ["d", "e", "f"]));
+      assert(
+        graph.add("a", "b").add("c").add("d", "e").add("e", "f")
+          .has(["a", "b"], "c", ["d", "e", "f"]),
+      );
+    });
   });
 
   it("adds vertices", () => {
@@ -116,13 +141,10 @@ describe("DirectedGraph", () => {
   });
 
   it("adds edges", () => {
-    assert(!graph.has("a"));
-    assert(!graph.has("b"));
+    assert(!graph.has("a", "b"));
 
     graph.add("a", "b").add("a", "c");
-    assert(graph.has("a"));
-    assert(graph.has("b"));
-    assert(graph.has("c"));
+    assert(graph.has("a", "b", "c"));
     assert(graph.edgesFrom("a").has("b"));
     assert(graph.edgesFrom("a").has("c"));
     assert(graph.edgesFrom("a").size === 2);
@@ -146,8 +168,7 @@ describe("DirectedGraph", () => {
 
   it("removes edges", () => {
     graph.add("a", "b").remove("a", "b");
-    assert(graph.has("a"));
-    assert(graph.has("b"));
+    assert(graph.has("a", "b"));
     assert(!graph.edgesFrom("a").has("b"));
     assert(!graph.edgesTo("b").has("a"));
   });
@@ -155,8 +176,7 @@ describe("DirectedGraph", () => {
   it("removes edges of a removed vertex", () => {
     graph.add("a", "b").add("a", "c").remove("a");
     assert(!graph.has("a"));
-    assert(graph.has("b"));
-    assert(graph.has("c"));
+    assert(graph.has("b", "c"));
     assert(!graph.edgesTo("b").has("a"));
     assert(!graph.edgesTo("c").has("a"));
   });

--- a/graph/DirectedGraph.ts
+++ b/graph/DirectedGraph.ts
@@ -286,32 +286,21 @@ export class DirectedGraph<T> {
     this.#edgesTo.get(target)!.delete(source);
   }
 
-  #removeEdges(source: Vertex<T>, targets: Iterable<Vertex<T>>): void {
-    this.#assertVertex(source);
-
-    for (const target of targets) {
-      this.#assertVertex(target);
-
-      this.#edgesFrom.get(source)!.delete(target);
-      this.#edgesTo.get(target)!.delete(source);
+  #removePath(path: Path<T>): void {
+    for (let i = 0; i < path.length - 1; i++) {
+      const j = i + 1;
+      this.#removeEdge(path[i], path[j]);
     }
   }
 
-  remove(vertex: Vertex<T>): this;
-  /** Remove edges from the source vertex to the target vertices.
-   *
-   * @example
-   * const graph = new DirectedGraph<string>();
-   * graph.add(["a", "b"]); // add a, b, a -> b
-   * graph.remove("a", "b"); // remove a -> b
-   */
-  remove(source: Vertex<T>, targets: Vertex<T> | Iterable<Vertex<T>>): this;
-  remove(source: Vertex<T>, targets?: Vertex<T> | Iterable<Vertex<T>>): this {
-    targets === undefined
-      ? this.#removeVertex(source)
-      : typeof targets === "object" && Symbol.iterator in targets
-      ? this.#removeEdges(source, targets)
-      : this.#removeEdge(source, targets);
+  remove(...inputs: Array<Vertex<T> | Edge<T> | Path<T>>): this {
+    for (const input of inputs) {
+      if (Array.isArray(input)) {
+        this.#removePath(input as Edge<T> | Path<T>);
+      } else {
+        this.#removeVertex(input);
+      }
+    }
 
     return this;
   }

--- a/graph/DirectedGraph.ts
+++ b/graph/DirectedGraph.ts
@@ -1,6 +1,15 @@
 import { VertexError } from "./errors.ts";
 
-export type Vertex<T> = NonNullable<T>;
+/** A `string`, `number`, `symbol`, or non-Array object member of the graph. */
+// deno-lint-ignore no-explicit-any
+export type Vertex<T> = T extends any[] ? never
+  // deno-lint-ignore no-explicit-any
+  : T extends Record<any, any> ? T
+  : T extends string ? T
+  : T extends number ? T
+  : T extends symbol ? T
+  : never;
+
 export type Vertices<T> = Set<Vertex<T>>;
 export type Edge<T> = [from: Vertex<T>, to: Vertex<T>];
 export type Path<T> = [Vertex<T>, ...Vertex<T>[]];
@@ -21,6 +30,7 @@ export class DirectedGraph<T> {
   #edgesTo = new Map<Vertex<T>, Vertices<T>>();
   #edgesFrom = new Map<Vertex<T>, Vertices<T>>();
 
+  /** Vertices can be `string`, `number`, `symbol`, or non-Array objects. */
   constructor(
     graphLike?: {
       vertices?: Iterable<Vertex<T>>;

--- a/graph/DirectedGraph.ts
+++ b/graph/DirectedGraph.ts
@@ -22,7 +22,7 @@ export type WalkOptions = {
 };
 
 export declare namespace DirectedGraph {
-  export { Path, Visitor, WalkOptions };
+  export { Edge, Path, Vertex, Vertices, Visitor, WalkOptions };
 }
 
 export class DirectedGraph<T> {

--- a/graph/DirectedGraph.ts
+++ b/graph/DirectedGraph.ts
@@ -36,7 +36,6 @@ export class DirectedGraph<T> {
 
       if (graphLike.edges) {
         for (const [source, target] of graphLike.edges) {
-          this.#addVertex(source);
           this.#addEdge(source, target);
         }
       }

--- a/graph/DirectedGraph.ts
+++ b/graph/DirectedGraph.ts
@@ -30,7 +30,30 @@ export class DirectedGraph<T> {
   #edgesTo = new Map<Vertex<T>, Vertices<T>>();
   #edgesFrom = new Map<Vertex<T>, Vertices<T>>();
 
-  /** Vertices can be `string`, `number`, `symbol`, or non-Array objects. */
+  /** Vertices can be `string`, `number`, `symbol`, or non-Array objects.
+   *
+   * @example
+   * const graph = new DirectedGraph<string>();
+   *
+   * graph.add("a", "b");
+   * // adds vertices "a" and "b" and the edge "a" -> "b"
+   *
+   * @example
+   * new DirectedGraph<number>().add(1, 2).add(3).remove(2);
+   *
+   * @example
+   * new DirectedGraph<symbol>()
+   *   .add(Symbol.for("1"), Symbol.for("2"));
+   *
+   * @example
+   * new DirectedGraph<{ name: string }>()
+   *   .add({ name: "a" }, { name: "b" });
+   *
+   * @example
+   * new DirectedGraph({
+   *   vertices: ["a", "b", "c"],
+   *   edges: [["a", "b"], ["b", "c"]],
+   * }) */
   constructor(
     graphLike?: {
       vertices?: Iterable<Vertex<T>>;
@@ -339,7 +362,13 @@ export class DirectedGraph<T> {
    * @param options.reverse If true, walk the graph in reverse
    * @param options.includeSource If true, call the visitor function for the source vertex
    * @returns The value returned by the visitor function, or undefined if the visitor function never returned a value.
-   */
+   *
+   * @example
+   * new DirectedGraph({ edges: [["a", "b"], ["b", "c"], ["c", "d"]] })
+   *   .walk("a", (v, path) => console.log(v, path));
+   * // "b" ["a", "b"]
+   * // "c" ["a", "b", "c"]
+   * // "d" ["a", "b", "c", "d"] */
   walk<R>(
     source: Vertex<T>,
     visitor: Visitor<T, R>,
@@ -359,6 +388,12 @@ export class DirectedGraph<T> {
       : this.#walkDepthFirst(source, [source], visitor, reverse, skipVisited);
   }
 
+  /** Return all paths from the source vertex to the target vertex.
+   *
+   * @example
+   * new DirectedGraph({ edges: [["a", "b"], ["b", "c"], ["a", "c"]] })
+   *   .paths("a", "c");
+   * // [["a", "b", "c"], ["a", "c"]] */
   paths(source: Vertex<T>, target: Vertex<T>): Path<T>[] {
     this.#assertVertex(source);
     this.#assertVertex(target);
@@ -369,6 +404,13 @@ export class DirectedGraph<T> {
     return paths;
   }
 
+  /** Return a new graph containing only the given vertices and the edges
+   * between them.
+   *
+   * @example
+   * new DirectedGraph({ edges: [["a", "b"], ["b", "c"]] })
+   *   .subgraph(["a", "b"]);
+   * //    ^ contains vertices "a" and "b" and the edge "a" -> "b" */
   subgraph(vertices: Iterable<Vertex<T>>): DirectedGraph<T> {
     const subgraph = new DirectedGraph<T>();
 

--- a/graph/DirectedGraph.ts
+++ b/graph/DirectedGraph.ts
@@ -59,17 +59,27 @@ export class DirectedGraph<T> {
   }
 
   get roots(): Vertices<T> {
-    return new Set(
-      [...this.#vertices]
-        .filter((vertex) => this.#edgesTo.get(vertex)!.size === 0),
-    );
+    const vertices: Vertices<T> = new Set();
+
+    for (const vertex of this.#vertices) {
+      if (this.#edgesTo.get(vertex)!.size === 0) {
+        vertices.add(vertex);
+      }
+    }
+
+    return vertices;
   }
 
   get leaves(): Vertices<T> {
-    return new Set(
-      [...this.#vertices]
-        .filter((vertex) => this.#edgesFrom.get(vertex)!.size === 0),
-    );
+    const vertices: Vertices<T> = new Set();
+
+    for (const vertex of this.#vertices) {
+      if (this.#edgesFrom.get(vertex)!.size === 0) {
+        vertices.add(vertex);
+      }
+    }
+
+    return vertices;
   }
 
   /** Mutates `visited`, providing information about which nodes were visited.

--- a/graph/DirectedGraph.ts
+++ b/graph/DirectedGraph.ts
@@ -190,8 +190,25 @@ export class DirectedGraph<T> {
     if (!this.#vertices.has(vertex)) throw new VertexError(vertex);
   }
 
-  has(vertex: Vertex<T>): boolean {
-    return this.#vertices.has(vertex);
+  #hasPath(path: Path<T>): boolean {
+    for (let i = 0; i < path.length - 1; i++) {
+      const j = i + 1;
+      if (!this.#edgesFrom.get(path[i])?.has(path[j])) return false;
+    }
+
+    return true;
+  }
+
+  has(...inputs: Array<Vertex<T> | Edge<T> | Path<T>>): boolean {
+    for (const input of inputs) {
+      const _has = Array.isArray(input)
+        ? this.#hasPath(input as Edge<T> | Path<T>)
+        : this.#vertices.has(input);
+
+      if (!_has) return false;
+    }
+
+    return true;
   }
 
   /** Returns all vertices that have an edge to the given vertex. */
@@ -420,7 +437,7 @@ export class DirectedGraph<T> {
     }
 
     for (const [source, target] of this.edges) {
-      if (subgraph.has(source) && subgraph.has(target)) {
+      if (subgraph.has(source, target)) {
         subgraph.add(source, target);
       }
     }

--- a/readme.md
+++ b/readme.md
@@ -140,8 +140,8 @@ const graph = new DirectedGraph<string>()
   .add("a")
   .add("b", ["a", "c"]);
 
-graph.vertices; // ["a", "b", "c"]
-graph.edges; // [["b", "a"], ["b", "c"]]
+graph.vertices; // new Set(["a", "b", "c"])
+graph.edges; // new Set([["a", "c"]])
 ```
 
 ## `io`

--- a/readme.md
+++ b/readme.md
@@ -136,7 +136,7 @@ Graph-related utilities.
 ```ts
 import { DirectedGraph } from "https://deno.land/x/handy/graph/utils.ts";
 
-const graph = new DirectedGraph()
+const graph = new DirectedGraph<string>()
   .add("a")
   .add("b", ["a", "c"]);
 


### PR DESCRIPTION
## Documentation

* (DirectedGraph): add JSDoc examples (8c29fa1)

## Features

* (DirectedGraph): `.has()` accepts edges, paths, and is variadic (b69c485)

* (DirectedGraph): `.add()` accepts edges, paths, and is variadic (df6f6b1)

* (DirectedGraph): `.remove()` accepts edges, paths, and is variadic (f54d7c1)

* (DirectedGraph): namespace typedefs (cdbe1ed)

## Fixes

* **Breaking Change** (DirectedGraph): constrain and document vertex types (e589d41)

  Previously vertices were `NonNullable` but this still allowed problematic `boolean`, `unknown`, and Array types. This commit constrains vertices to `string`, `number`, `symbol`, and non-Array objects, preventing confusion and setting up for API improvements that rely on arrays to represent edges and paths.

## Refactors

* (DirectedGraph): remove duplicative #addVertex call (1ac07f4)

* (DirectedGraph): prefer `for` loops (a21c151)

## Tests

* (DirectedGraph): use assertion helpers (edc1ce9)