### PR TITLE
/md/codeBlocks: `CodeBlockDetails` includes lineNumbers from `findAll()`

### DIFF
--- a/md/codeBlock/eval.test.ts
+++ b/md/codeBlock/eval.test.ts
@@ -57,8 +57,9 @@ describe("evaluateAll", () => {
       );
 
       assertEquals(results.size, 2);
-      for (const [node, result] of results) {
-        assert(node.type === "indented");
+      for (const [details, result] of results) {
+        assert(details.type === "indented");
+        assert(typeof details.lineNumber === "number");
         assert(result instanceof IndentedCodeBlockError);
       }
     });
@@ -74,6 +75,7 @@ describe("evaluateAll", () => {
       assertEquals(results.size, 2);
       for (const [details, err] of results) {
         assert(details.type === "fenced");
+        assert(typeof details.lineNumber === "number");
         assert(err instanceof NoLanguageError);
       }
     });
@@ -87,6 +89,7 @@ describe("evaluateAll", () => {
       assertEquals(results.size, 2);
       for (const [details, err] of results) {
         assert(details.type === "fenced");
+        assert(typeof details.lineNumber === "number");
         assert(err instanceof UnknownLanguageError);
       }
     });
@@ -98,8 +101,9 @@ describe("evaluateAll", () => {
       );
 
       assertEquals(results.size, 2);
-      for (const [node, result] of results) {
-        assert(node.type === "fenced");
+      for (const [details, result] of results) {
+        assert(details.type === "fenced");
+        assert(typeof details.lineNumber === "number");
         assert(!(result instanceof Error));
         if (!result.success) {
           assertEquals(result.code, 1);

--- a/md/codeBlock/eval.ts
+++ b/md/codeBlock/eval.ts
@@ -78,7 +78,7 @@ export async function evaluateAll(
   > = new Map();
 
   for (const codeBlock of findAllCodeBlocks(markdown)) {
-    const details = parseCodeBlock(codeBlock);
+    const details = parseCodeBlock(codeBlock.code, codeBlock.lineNumber);
 
     try {
       const code = _getCode(details, replace);

--- a/md/codeBlock/fenced.test.ts
+++ b/md/codeBlock/fenced.test.ts
@@ -105,17 +105,21 @@ describe("parse", () => {
         char: "`",
         fence: "```",
         code: "Hello!",
+        lineNumber: 1,
       },
     ));
 });
 
 describe("findAll", () => {
-  it("finds all code blocks in a string", () =>
+  it("finds all fenced code blocks in a string", () =>
     assertEquals(
       findAll(
         "foo\n\n    bar\n\n```baz\nqux\n```" +
           "   quux\n\n```corge\ngrault\n```",
       ),
-      ["```baz\nqux\n```", "```corge\ngrault\n```"],
+      [{ code: "```baz\nqux\n```", lineNumber: 5 }, {
+        code: "```corge\ngrault\n```",
+        lineNumber: 9,
+      }],
     ));
 });

--- a/md/codeBlock/findAll.test.ts
+++ b/md/codeBlock/findAll.test.ts
@@ -5,6 +5,9 @@ describe("findAll", () => {
   it("finds all code blocks in a string", () =>
     assertEquals(
       findAll("foo\n\n    bar\n\n```baz\nqux\n```"),
-      ["    bar", "```baz\nqux\n```"],
+      [{ code: "    bar", lineNumber: 3 }, {
+        code: "```baz\nqux\n```",
+        lineNumber: 5,
+      }],
     ));
 });

--- a/md/codeBlock/findAll.ts
+++ b/md/codeBlock/findAll.ts
@@ -1,7 +1,18 @@
 import { CODE_BLOCK_REGEX } from "./regex.ts";
-/** Find all code blocks in a markdown string. */
-export function findAll(markdown: string): string[] {
-  const matches = markdown.matchAll(CODE_BLOCK_REGEX);
+import type { CodeBlockInfo } from "./types.ts";
 
-  return [...matches].map((match) => match[0]);
+/** Find all code blocks in a markdown string. */
+export function findAll(markdown: string): CodeBlockInfo[] {
+  const matches = [...markdown.matchAll(CODE_BLOCK_REGEX)];
+
+  return matches.map((match) => {
+    const code = match[0];
+    const lineNumber = getLineNumber(markdown, match.index ?? 0);
+    return { code, lineNumber };
+  });
+}
+
+function getLineNumber(text: string, index: number): number {
+  const lines = text.slice(0, index).split("\n");
+  return lines.length;
 }

--- a/md/codeBlock/indented.test.ts
+++ b/md/codeBlock/indented.test.ts
@@ -58,12 +58,15 @@ describe("parse", () => {
 });
 
 describe("findAll", () => {
-  it("finds all code blocks in a string", () =>
+  it("finds all indented code blocks in a string", () =>
     assertEquals(
       findAll(
         "ex\n    foo\n\n    bar\n\n```baz\nqux\n```\n" +
           "      quux\n\n```corge\ngrault\n```",
       ),
-      ["    foo\n\n    bar", "      quux"],
+      [{ code: "    foo\n\n    bar", lineNumber: 2 }, {
+        code: "      quux",
+        lineNumber: 9,
+      }],
     ));
 });

--- a/md/codeBlock/parse.test.ts
+++ b/md/codeBlock/parse.test.ts
@@ -9,6 +9,7 @@ describe("parse", () => {
         type: "indented",
         indentation: "    ",
         code: "foo\nbar",
+        lineNumber: 1,
       },
     ));
 
@@ -22,6 +23,7 @@ describe("parse", () => {
         lang: "lang",
         meta: "meta data",
         code: "foo\nbar",
+        lineNumber: 1,
       },
     ));
 });

--- a/md/codeBlock/parse.ts
+++ b/md/codeBlock/parse.ts
@@ -2,8 +2,8 @@ import { parse as parseFenced } from "./fenced.ts";
 import { parse as parseIndented } from "./indented.ts";
 import type { CodeBlockDetails } from "./types.ts";
 
-export function parse(codeBlock: string): CodeBlockDetails {
+export function parse(codeBlock: string, lineNumber = 1): CodeBlockDetails {
   return codeBlock[0] === " "
-    ? parseIndented(codeBlock)
-    : parseFenced(codeBlock);
+    ? parseIndented(codeBlock, lineNumber)
+    : parseFenced(codeBlock, lineNumber);
 }

--- a/md/codeBlock/types.ts
+++ b/md/codeBlock/types.ts
@@ -1,6 +1,11 @@
 import { FencedCodeBlockDetails } from "./fenced.ts";
 import { IndentedCodeBlockDetails } from "./indented.ts";
 
+export type CodeBlockInfo = {
+  code: string;
+  lineNumber: number;
+};
+
 export type CodeBlockDetails =
   | IndentedCodeBlockDetails
   | FencedCodeBlockDetails;

--- a/md/script/evalCodeBlocks.ts
+++ b/md/script/evalCodeBlocks.ts
@@ -59,7 +59,7 @@ export async function evalCodeBlocks(
     const inlineCode = code.trim().replace(/\s+/g, " ");
     const firstChars = inlineCode.slice(
       0,
-      consoleWidth - langLength - iconLength - 5,
+      consoleWidth - langLength - iconLength - 6,
     );
 
     const message = firstChars.length < inlineCode.length
@@ -67,6 +67,10 @@ export async function evalCodeBlocks(
       : `${colorIcon} ${details.lang} ${firstChars}`;
 
     console.log(message);
+    if (result instanceof Error || !result.success) {
+      const source = `→ error evaluating at ${filePath}:${details.lineNumber}`;
+      console.log(source);
+    }
   }
 
   return results;


### PR DESCRIPTION
Closes #42 

`FindAll()` now returns new `type CodeBlockInfo` which includes `lineNumber`:
```
findAll("foo\n\n    bar\n\n```baz\nqux\n```")
```
results in 
```
[{ code: "    bar", lineNumber: 3 }, 
{code: "```baz\nqux\n```", lineNumber: 5}]
```

....which optionally pass through `Parse(code,lineNumber)` to be included in `CodeBlockDetails` which extends `CodeBlockInfo`
 - not necessary?
 - it felt like the original lineNumber of the codeBlock belonged in `CodeBlockDetails`
```
{
        type: "fenced",
        char: "`",
        fence: "```",
        lang: "lang",
        meta: "meta data",
        code: "foo\nbar",
        lineNumber: 1,
      }
```

Either way this supports feeding to error messages of `results = eval()` (not yet implemented)
```
for (const codeBlock of findAllCodeBlocks(markdown)) {
    //original codeBlock.lineNumber from markdown passed to parse()
    const details = parseCodeBlock(codeBlock.code, codeBlock.lineNumber);
    // details.lineNumber to be used in error messages
    try {
      const code = _getCode(details, replace);
      const result = await evalTS(code);

      results.set(details, result);
    } catch (error) {
      if (
        error instanceof IndentedCodeBlockError ||
        error instanceof NoLanguageError ||
        error instanceof UnknownLanguageError
      ) {
        results.set(details, error);
      } else {
        results.set(details, new Error("Unknown error", { cause: error }));
      }
    }
  }
```