### PR TITLE
docs: fix incorrect readme comment

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,9 +30,9 @@ import { mapOnInterval } from "https://deno.land/x/handy/array/utils.ts";
 
 mapOnInterval([3, 2, 1, "go!"], 100, (item) => console.log(item));
 // logs: 3
-// 1sec later, logs: 2
-// 1sec later, logs: 1
-// 1sec later, logs: "go!"
+// 100ms later, logs: 2
+// 100ms later, logs: 1
+// 100ms later, logs: "go!"
 ```
 
 ## `cli`


### PR DESCRIPTION
`1000` was down-tuned to `100` to make the `test-readme` task faster, but the comment wasn't updated to match.