### PR TITLE
refactor(ts): `Intersect` -> `Pretty`

### DIFF
--- a/cli/cmd.ts
+++ b/cli/cmd.ts
@@ -1,4 +1,4 @@
-import type { Intersect } from "../ts/types.ts";
+import type { Pretty } from "../ts/types.ts";
 
 export type CmdOptions = {
   cwd?: string;
@@ -6,7 +6,7 @@ export type CmdOptions = {
   fullResult?: boolean;
 };
 
-export type CmdResult = Intersect<
+export type CmdResult = Pretty<
   & Pick<Deno.CommandOutput, "code" | "success">
   & { stdout: string; stderr: string }
 >;

--- a/md/codeBlock/fenced.ts
+++ b/md/codeBlock/fenced.ts
@@ -1,9 +1,9 @@
 import { mostConsecutive } from "../../string/sequence.ts";
-import type { Intersect } from "../../ts/types.ts";
+import type { Pretty } from "../../ts/types.ts";
 import * as infoString from "./infoString.ts";
 import { FENCED_CODE_BLOCK_REGEX } from "./regex.ts";
 
-export type FencedCodeBlockDetails = Intersect<
+export type FencedCodeBlockDetails = Pretty<
   & {
     type: "fenced";
     char: FenceChar;
@@ -15,7 +15,7 @@ export type FencedCodeBlockDetails = Intersect<
 
 export type FenceChar = "`" | "~";
 
-export type CreateFencedOptions = Intersect<
+export type CreateFencedOptions = Pretty<
   & {
     /** If `lang` or `meta` contain backticks, `char` will be set to "~" and
      * this option will be ignored. */

--- a/readme.md
+++ b/readme.md
@@ -289,3 +289,13 @@ import { evaluate } from "https://deno.land/x/handy/ts/utils.ts";
 await evaluate("console.log('Hello!')")
   .then((res) => res.stdout); // "Hello!"
 ```
+
+```ts
+import type { Pretty } from "https://deno.land/x/handy/ts/types.ts";
+
+type Input = { a: number } & { b: string };
+//     ^? { a: number } & { b: string }
+
+type Prettified = Pretty<Input>;
+//     ^? { a: number; b: string }
+```

--- a/ts/evaluate.ts
+++ b/ts/evaluate.ts
@@ -1,7 +1,7 @@
 import { cmd, CmdOptions, CmdResult } from "../cli/cmd.ts";
-import type { Intersect } from "./types.ts";
+import type { Pretty } from "./types.ts";
 
-export type EvaluateTypeScriptOptions = Intersect<
+export type EvaluateTypeScriptOptions = Pretty<
   & Pick<CmdOptions, "cwd" | "env">
   & { typeCheck?: boolean }
 >;

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -1,12 +1,15 @@
-/** Represent an object type with all properties merged into the top level,
- * handling intersections (`&`).
+/** Represents a type with all properties merged into the top level, handling
+ * intersections (`&`), often resulting in more legible shapes particularly
+ * for object types.
+ *
+ * Source: https://twitter.com/mattpocockuk/status/1622730173446557697
  *
  * @example
  * type USCity = { city: string, state: string };
  * type USAddress = USCity & { street: string, zip: string };
  * //   ^? USCity & { street: string, zip: string }
  *
- * type USAddress = Intersect<USCity & { street: string, zip: string }>;
+ * type USAddress = Pretty<USCity & { street: string, zip: string }>;
  * //   ^? { city: string, state: string, street: string, zip: string } */
-// deno-lint-ignore no-explicit-any
-export type Intersect<T extends Record<any, any>> = { [K in keyof T]: T[K] };
+// deno-lint-ignore ban-types
+export type Pretty<T> = { [K in keyof T]: T[K] } & {};


### PR DESCRIPTION
Extracted from #79.

- refactor(ts): `Intersect` -> `Pretty`; expand input types; add `& {}`; docs

  This refactor brings this helper type in line with [the original inspiration](https://twitter.com/mattpocockuk/status/1622730173446557697). During #79 I encountered situations where the `& {}` was necessary to coax the compiler into untangling complex types. I also learned that the `Record`-based type constraint was unnecessary, and that this helper has uses beyond just handling intersections, so I opted to fully implement the original helper except with a shorter name. I also took this opportunity to add a readme entry.