### PR TITLE
feat(cli): add console size helpers

### DIFF
--- a/cli/consoleSize.ts
+++ b/cli/consoleSize.ts
@@ -1,0 +1,28 @@
+export type ConsoleSize = { columns: number; rows: number };
+
+/** Get the size of the console or fallback to the given size. */
+export function consoleSize(fallback: ConsoleSize): ConsoleSize {
+  try {
+    return Deno.consoleSize();
+  } catch {
+    return fallback;
+  }
+}
+
+/** Get the width of the console as an integer count of columns. */
+export function consoleWidth(fallback: number): number {
+  try {
+    return Deno.consoleSize().columns;
+  } catch {
+    return fallback;
+  }
+}
+
+/** Get the height of the console as an integer count of rows. */
+export function consoleHeight(fallback: number): number {
+  try {
+    return Deno.consoleSize().rows;
+  } catch {
+    return fallback;
+  }
+}

--- a/cli/utils.ts
+++ b/cli/utils.ts
@@ -1,1 +1,2 @@
 export * from "./cmd.ts";
+export * from "./consoleSize.ts";

--- a/git/script/makeReleaseNotes.ts
+++ b/git/script/makeReleaseNotes.ts
@@ -8,6 +8,7 @@ import {
 import { getSpan as getCommitSpan } from "../commit/get.ts";
 import { CommitDescription } from "../commit/types.ts";
 import { getLatest as getLatestTag } from "../tag.ts";
+import { consoleWidth } from "../../cli/consoleSize.ts";
 
 type CommitInfo = ConventionalCommit & Omit<CommitDescription, "message">;
 
@@ -40,9 +41,7 @@ async function commits(
   log(`  Commits since ${commit}: ${rawCommits.length}`);
 
   const commits: CommitInfo[] = [];
-  const terminalWidth = Deno.isatty(Deno.stdout.rid)
-    ? Deno.consoleSize().columns
-    : 80;
+  const terminalWidth = consoleWidth(80);
 
   for (const { message, author, date, hash: longHash } of rawCommits) {
     const hash = longHash.substring(0, 7);

--- a/md/script/evalCodeBlocks.ts
+++ b/md/script/evalCodeBlocks.ts
@@ -1,5 +1,6 @@
 import { gray, green, red } from "../../_deps/fmt.ts";
 import { CmdResult } from "../../cli/cmd.ts";
+import { consoleWidth } from "../../cli/consoleSize.ts";
 import {
   evaluateAll,
   EvaluateOptions,
@@ -24,10 +25,8 @@ export async function evalCodeBlocks(
   const markdown = await Deno.readTextFile(filePath);
   console.log(`Executing code blocks in ${filePath}`);
 
-  const consoleWidth = Deno.isatty(Deno.stdout.rid)
-    ? Deno.consoleSize().columns
-    : 80;
-  console.log("-".repeat(consoleWidth));
+  const width = consoleWidth(80);
+  console.log("-".repeat(width));
 
   const results = await evaluateAll(markdown, { replace });
 
@@ -59,7 +58,7 @@ export async function evalCodeBlocks(
     const inlineCode = code.trim().replace(/\s+/g, " ");
     const firstChars = inlineCode.slice(
       0,
-      consoleWidth - langLength - iconLength - 5,
+      width - langLength - iconLength - 5,
     );
 
     const message = firstChars.length < inlineCode.length

--- a/readme.md
+++ b/readme.md
@@ -51,9 +51,10 @@ type Deed = Tuple.FromIndices<["d", "e"], [0, 1, 1, 0]>; // ["d", "e", "e", "d"]
 CLI-related utilities.
 
 ```ts
-import { cmd } from "https://deno.land/x/handy/cli/utils.ts";
+import { cmd, consoleWidth } from "https://deno.land/x/handy/cli/utils.ts";
 
 await cmd("echo Hello!"); // "Hello!"
+consoleWidth(80); // real width of terminal, or fallback of 80
 ```
 
 ## `collection`


### PR DESCRIPTION
See #93 

- feat(cli): add console size helpers

  - `consoleWidth()` returns the actual console width in columns, else a fallback value when unable.
  
  - `consoleHeight()` does the same for height in rows.
  
  - `consoleSize()` does both at once.