### PR TITLE
Add `elide` helpers

### DIFF
--- a/git/script/makeReleaseNotes.ts
+++ b/git/script/makeReleaseNotes.ts
@@ -9,6 +9,7 @@ import { getSpan as getCommitSpan } from "../commit/get.ts";
 import { CommitDescription } from "../commit/types.ts";
 import { getLatest as getLatestTag } from "../tag.ts";
 import { consoleWidth } from "../../cli/consoleSize.ts";
+import { elideEnd } from "../../string/elide.ts";
 
 type CommitInfo = ConventionalCommit & Omit<CommitDescription, "message">;
 
@@ -58,7 +59,7 @@ async function commits(
       commits.push({ hash, author, date, ...conventionalCommit });
     } catch {
       log(`  Ignoring unconventional commit  ${hash}`);
-      log(`    ${message.substring(0, terminalWidth - 7)}...`);
+      log(`    ${elideEnd(message, { maxLength: terminalWidth - 4 })}`);
     }
   }
 

--- a/md/script/evalCodeBlocks.ts
+++ b/md/script/evalCodeBlocks.ts
@@ -1,6 +1,7 @@
 import { gray, green, red } from "../../_deps/fmt.ts";
 import { CmdResult } from "../../cli/cmd.ts";
 import { consoleWidth } from "../../cli/consoleSize.ts";
+import { elideEnd } from "../../string/elide.ts";
 import {
   evaluateAll,
   EvaluateOptions,
@@ -55,15 +56,13 @@ export async function evalCodeBlocks(
     const iconLength = icon === "skip" ? 4 : 1;
     const langLength = String(lang).length;
 
-    const inlineCode = code.trim().replace(/\s+/g, " ");
-    const firstChars = inlineCode.slice(
-      0,
-      width - langLength - iconLength - 5,
-    );
+    const prefix = `${colorIcon} ${details.lang} `;
+    const spacesInPrefix = 2;
 
-    const message = firstChars.length < inlineCode.length
-      ? `${colorIcon} ${details.lang} ${firstChars}...`
-      : `${colorIcon} ${details.lang} ${firstChars}`;
+    const inlineCode = code.trim().replace(/\s+/g, " ");
+    const maxLength = width - langLength - iconLength - spacesInPrefix;
+
+    const message = `${prefix}${elideEnd(inlineCode, { maxLength })}`;
 
     console.log(message);
   }

--- a/readme.md
+++ b/readme.md
@@ -338,6 +338,7 @@ String-related utilities.
 ```ts
 import {
   dedent,
+  elideStart, // and others
   indent,
   location,
   mostConsecutive,
@@ -349,6 +350,7 @@ import {
 dedent("  a\n   b\n    c"); // "a\n b\n  c"
 indent("a\nb\nc", 2); // "  a\n  b\n  c"
 location("a\nb\nc", 5); // { line: 2, column: 2, offset: 5 }
+elideStart("1234567890", { maxLength: 8 }); // "…4567890"
 splitOnFirst("/", "a/b/c"); // ["a", "b/c"]
 splitOn(3, "\n", "a\nb\nc\nd\ne"); // ["a", "b", "c", "d\ne"]
 sequences("A", "ABAACA"); // ["A", "AA", "A"]

--- a/string/elide.test.ts
+++ b/string/elide.test.ts
@@ -1,0 +1,99 @@
+import { assertEquals, describe, it } from "../_deps/testing.ts";
+import { elideAround, elideEnd, elideMiddle, elideStart } from "./elide.ts";
+
+const digits = "1234567890";
+const len70 = digits.repeat(7);
+const len90 = digits.repeat(9);
+
+describe("elideStart", () => {
+  it("defaults to len 80 and …", () =>
+    assertEquals(elideStart(len90), "…" + len90.slice(90 - 79)));
+
+  it("forwards short strings", () => assertEquals(elideStart(len70), len70));
+
+  it("can customize maxLength", () =>
+    assertEquals(elideStart(digits, { maxLength: 8 }), "…4567890"));
+
+  it("can customize ellipses", () =>
+    assertEquals(
+      elideStart(len90, { ellipsis: "..." }),
+      "..." + len90.slice(90 - 77),
+    ));
+});
+
+describe("elideEnd", () => {
+  it("defaults to len 80 and …", () =>
+    assertEquals(elideEnd(len90), len90.slice(0, 79) + "…"));
+
+  it("forwards short strings", () => assertEquals(elideEnd(len70), len70));
+
+  it("can customize maxLength", () =>
+    assertEquals(elideEnd(digits, { maxLength: 8 }), "1234567…"));
+
+  it("can customize ellipses", () =>
+    assertEquals(
+      elideEnd(len90, { ellipsis: "..." }),
+      len90.slice(0, 77) + "...",
+    ));
+});
+
+describe("elideMiddle", () => {
+  it("defaults to len 80 and …", () =>
+    assertEquals(
+      elideMiddle(len90),
+      len90.slice(0, 40) + "…" + len90.slice(90 - 39),
+    ));
+
+  it("forwards short strings", () => assertEquals(elideMiddle(len70), len70));
+
+  it("can customize maxLength", () =>
+    assertEquals(
+      elideMiddle(digits, { maxLength: 8 }),
+      "1234…890",
+    ));
+
+  it("can customize ellipses", () =>
+    assertEquals(
+      elideMiddle(len90, { ellipsis: "..." }),
+      len90.slice(0, 39) + "..." + len90.slice(90 - 38),
+    ));
+});
+
+describe("elideAround", () => {
+  it("defaults to len 80 and …", () =>
+    assertEquals(
+      elideAround(len90, 45),
+      ["…" + len90.slice(45 - 39, 45 + 39) + "…", 40],
+    ));
+
+  it("forwards short strings", () =>
+    assertEquals(elideAround(len70, 0), [len70, 0]));
+
+  it("can customize maxLength", () => {
+    assertEquals(elideAround(digits, 5, { maxLength: 8 }), ["…345678…", 4]);
+    assertEquals(elideAround(digits, 5, { maxLength: 7 }), ["…45678…", 3]);
+    assertEquals(elideAround(digits, 5, { maxLength: 6 }), ["…4567…", 3]);
+    assertEquals(elideAround(digits, 5, { maxLength: 5 }), ["…567…", 2]);
+  });
+
+  it("can customize ellipses", () => {
+    assertEquals(
+      elideAround(len90, 45, { ellipsis: "..." }),
+      ["..." + len90.slice(45 - 37, 45 + 37) + "...", 40],
+    );
+  });
+
+  it("handles indices near the start", () => {
+    assertEquals(elideAround(digits, 2, { maxLength: 8 }), ["1234567…", 2]);
+    assertEquals(elideAround(digits, 2, { maxLength: 7 }), ["123456…", 2]);
+    assertEquals(elideAround(digits, 2, { maxLength: 6 }), ["12345…", 2]);
+    assertEquals(elideAround(digits, 2, { maxLength: 5 }), ["1234…", 2]);
+  });
+
+  it("handles indices near the end", () => {
+    assertEquals(elideAround(digits, 7, { maxLength: 8 }), ["…4567890", 5]);
+    assertEquals(elideAround(digits, 7, { maxLength: 7 }), ["…567890", 4]);
+    assertEquals(elideAround(digits, 7, { maxLength: 6 }), ["…67890", 3]);
+    assertEquals(elideAround(digits, 7, { maxLength: 5 }), ["…7890", 2]);
+  });
+});

--- a/string/elide.ts
+++ b/string/elide.ts
@@ -1,0 +1,101 @@
+export type ElideOptions = {
+  /** The maximum length of the returned string.
+   *
+   * @default 80 */
+  maxLength?: number;
+  /** The string to use as an ellipsis.
+   *
+   * @default "…" */
+  ellipsis?: string;
+};
+
+/** Elide the start of a string, keeping the end.
+ *
+ * @example
+ * elideStart("1234567890", { maxLength: 8 })
+ * // "…4567890" */
+export function elideStart(str: string, opts?: ElideOptions): string {
+  const { maxLength = 80, ellipsis = "…" } = opts ?? {};
+
+  if (str.length <= maxLength) return str;
+
+  const right = str.slice(-(maxLength - ellipsis.length));
+
+  return `${ellipsis}${right}`;
+}
+
+/** Elide the end of a string, keeping the start.
+ *
+ * @example
+ * elideEnd("1234567890", { maxLength: 8 })
+ * // "1234567…" */
+export function elideEnd(str: string, opts?: ElideOptions): string {
+  const { maxLength = 80, ellipsis = "…" } = opts ?? {};
+
+  if (str.length <= maxLength) return str;
+
+  const left = str.slice(0, maxLength - ellipsis.length);
+
+  return `${left}${ellipsis}`;
+}
+
+/** Elide the middle of a string, keeping the start and end. If the portions
+ * before and after the elided portion are not equal, the start is favored.
+ *
+ * @example
+ * elideMiddle("1234567890", { maxLength: 8 })
+ * // "1234…890" */
+export function elideMiddle(str: string, opts?: ElideOptions): string {
+  const { maxLength = 80, ellipsis = "…" } = opts ?? {};
+
+  if (str.length <= maxLength) return str;
+
+  const nonEllipsisLength = maxLength - ellipsis.length;
+  const leftLength = Math.ceil(nonEllipsisLength / 2);
+  const left = str.slice(0, leftLength);
+  const right = str.slice(-(nonEllipsisLength - leftLength));
+
+  return `${left}${ellipsis}${right}`;
+}
+
+/** Elide the start and end of a string, keeping the middle centered on
+ * `index`. If the portions before and after the index are not equal,
+ * the start is favored.
+ *
+ * @returns A tuple of the elided string and the `index` character's translated index position within the elided string.
+ *
+ * @example
+ * const str = "abcdefghij";
+ * const maxLength = 8;
+ * const index = 5; // str[5] = "f"
+ *
+ * const [elided, newIndex] = elideAround(str, index, { maxLength })
+ * //   "…cdefgh…",   4 (index of "f" within elided) */
+export function elideAround(
+  str: string,
+  index: number,
+  opts?: ElideOptions,
+): [result: string, indexPosition: number] {
+  const { maxLength = 80, ellipsis = "…" } = opts ?? {};
+
+  if (str.length <= maxLength) return [str, index];
+
+  const coreLength = maxLength - (ellipsis.length * 2);
+  const left = index - Math.floor(coreLength / 2);
+  const right = left + coreLength;
+
+  const leftTooSmall = left <= ellipsis.length;
+  if (leftTooSmall) return [elideEnd(str, opts), index];
+
+  const rightTooLarge = right >= str.length - ellipsis.length;
+  if (rightTooLarge) {
+    const elided = elideStart(str, opts);
+
+    return [elided, index - (str.length - elided.length)];
+  }
+
+  const middle = str.slice(left, right);
+  const newIndex = index - left + ellipsis.length;
+
+  return [`${ellipsis}${middle}${ellipsis}`, newIndex];
+}

--- a/string/utils.ts
+++ b/string/utils.ts
@@ -2,4 +2,5 @@ export * from "./splitOn.ts";
 export * from "./sequence.ts";
 export * from "./dedent.ts";
 export * from "./indent.ts";
+export * from "./elide.ts";
 export * from "./location.ts";


### PR DESCRIPTION
See #94

- feat(string): add `elide` helpers
  
  - `elideStart()` replaces the start of a string with ellipses
  
  - `elideEnd()` replaces the end of a string with ellipses
  
  - `elideMiddle()` replaces the middle of a string with ellipses
  
  - `elideAround()` dynamically elides the start and/or end of a string with ellipses, centered around a chosen index