### PR TITLE
Utility Types for `array`, `string`, `number`, `ts`, and `collection`

### DIFF
--- a/array/types.ts
+++ b/array/types.ts
@@ -3,7 +3,7 @@
  * @example
  * type A = Fill<[1, 2, 3], "a"> // ["a", "a", "a"]
  * type B = Fill<Array<unknown>, "b"> // Array<"b"> */
-export type Fill<T extends unknown[], Value> = {
+export type Fill<T extends readonly unknown[], Value> = {
   [K in keyof T]: Value;
 };
 
@@ -12,7 +12,8 @@ export type Fill<T extends unknown[], Value> = {
  *
  * @example
  * const items: Flat<[1, 2, [3, [4], 5]]> = [1, 2, 3, [4], 5]; */
-export type Flat<T extends unknown[]> = T extends [infer Head, ...infer Tail]
+export type Flat<T extends readonly unknown[]> = T extends
+  readonly [infer Head, ...infer Tail]
   ? Head extends unknown[] ? [...Head, ...Flat<Tail>]
   : [Head, ...Flat<Tail>]
   : [];
@@ -21,28 +22,28 @@ export type Flat<T extends unknown[]> = T extends [infer Head, ...infer Tail]
  *
  * @example
  * const items: Reverse<[1, 2, 3]> = [3, 2, 1] */
-export type Reverse<T extends unknown[]> = T extends [infer Head, ...infer Tail]
-  ? [...Reverse<Tail>, Head]
+export type Reverse<T extends readonly unknown[]> = T extends
+  readonly [infer Head, ...infer Tail] ? [...Reverse<Tail>, Head]
   : [];
 
-type _Indices<T extends unknown[]> = T extends [unknown, ...infer Tail]
-  ? [Tail["length"], ..._Indices<Tail>]
+type _Indices<T extends readonly unknown[]> = T extends
+  readonly [unknown, ...infer Tail] ? [Tail["length"], ..._Indices<Tail>]
   : [];
 
 /** Represents a tuple of the indices of `T`.
  *
  * @example
  * type A = Indices<["a", "b", "c"]> // [0, 1, 2] */
-export type Indices<T extends unknown[]> = Reverse<_Indices<T>>;
+export type Indices<T extends readonly unknown[]> = Reverse<_Indices<T>>;
 
 /** Represents one of the indices of `T`.
  *
  * @example
  * type A = Index<["a", "b", "c"]> // 0 | 1 | 2 */
-export type Index<T extends unknown[]> = Indices<T>[number];
+export type Index<T extends readonly unknown[]> = Indices<T>[number];
 
-type _FromIndices<T extends unknown[], I> = I extends
-  [infer Head extends keyof T, ...infer Tail extends Array<keyof T>]
+type _FromIndices<T extends readonly unknown[], I> = I extends
+  readonly [infer Head extends keyof T, ...infer Tail extends Array<keyof T>]
   ? [T[Head], ..._FromIndices<T, Tail>]
   : [];
 
@@ -51,8 +52,10 @@ type _FromIndices<T extends unknown[], I> = I extends
  * @example
  * type A = FromIndices<["n", "s", "o"], [1, 2, 2, 0]>
  * // ["s", "o", "o", "n"] */
-export type FromIndices<T extends unknown[], I extends Index<T>[]> =
-  _FromIndices<T, I>;
+export type FromIndices<
+  T extends readonly unknown[],
+  I extends readonly Index<T>[],
+> = _FromIndices<T, I>;
 
 /** Represents an array of length-2 tuples comprised of two arrays zippered
  * together.
@@ -60,12 +63,12 @@ export type FromIndices<T extends unknown[], I extends Index<T>[]> =
  * @example
  * type A = Zip<[1, 2, 3], ["a", "b", "c"]>
  * // [[1, "a"], [2, "b"], [3, "c"]] */
-export type Zip<A extends unknown[], B extends unknown[]> = A extends
-  [infer HeadA, ...infer TailA]
-  ? B extends [infer HeadB, ...infer TailB]
-    ? [[HeadA, HeadB], ...Zip<TailA, TailB>]
-  : []
-  : [];
+export type Zip<A extends readonly unknown[], B extends readonly unknown[]> =
+  A extends readonly [infer HeadA, ...infer TailA]
+    ? B extends readonly [infer HeadB, ...infer TailB]
+      ? [[HeadA, HeadB], ...Zip<TailA, TailB>]
+    : []
+    : [];
 
 /** Array utility types which are designed to respect tuples. */
 export declare namespace Tuple {

--- a/array/types.ts
+++ b/array/types.ts
@@ -1,3 +1,14 @@
+export type TypedArray =
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array;
+
 /** Represents an array whose items are replaced with `Value`.
  *
  * @example

--- a/array/types.ts
+++ b/array/types.ts
@@ -81,7 +81,25 @@ export type Zip<A extends readonly unknown[], B extends readonly unknown[]> =
     : []
     : [];
 
+/** Represents a tuple of length `N` comprised of `unknown` values.
+ *
+ * @example
+ * type A = TupleOfLength<3> // [unknown, unknown, unknown] */
+export type TupleOfLength<N extends number, Tuple extends unknown[] = []> =
+  Tuple["length"] extends N // When Tuple is finally of length N...
+    ? Tuple // ...return it.
+    : TupleOfLength<N, [...Tuple, unknown]>; // Otherwise, add another item.
+
 /** Array utility types which are designed to respect tuples. */
 export declare namespace Tuple {
-  export { Fill, Flat, FromIndices, Index, Indices, Reverse, Zip };
+  export {
+    Fill,
+    Flat,
+    FromIndices,
+    Index,
+    Indices,
+    Reverse,
+    TupleOfLength as OfLength,
+    Zip,
+  };
 }

--- a/collection/mod.ts
+++ b/collection/mod.ts
@@ -1,1 +1,2 @@
 export * from "./utils.ts";
+export * from "./types.ts";

--- a/collection/types.ts
+++ b/collection/types.ts
@@ -1,0 +1,29 @@
+import type { Tuple } from "../array/types.ts";
+import { Str } from "../string/types.ts";
+
+/** A type that can be indexed by a number and has a `length` property.
+ *
+ * @example
+ * const foo: IndexedCollection = ["a", "b", "c"]
+ * const bar: IndexedCollection = new Uint16Array(4)
+ * const baz: IndexedCollection = "abc" */
+export type IndexedCollection = ArrayLike<unknown>;
+
+/** Represents a tuple of the indices of `T`.
+ *
+ * @example
+ * type A = Indices<["a", "b", "c"]> // [0, 1, 2]
+ * type B = Indices<Uint16Array> // number[]
+ * type C = Indices<"abc"> // [0, 1, 2] */
+export type Indices<T extends IndexedCollection> = T extends string
+  ? Str.Indices<T>
+  : T extends readonly unknown[] ? Tuple.Indices<T>
+  : number[]; // If `T` is not a string or array, can't infer specific indices.
+
+/** Represents one of the indices of `T`.
+ *
+ * @example
+ * type A = Index<"abc"> // 0 | 1 | 2
+ * type B = Index<Uint16Array> // number
+ * type C = Index<["a", "b", "c"]> // 0 | 1 | 2 */
+export type Index<T extends IndexedCollection> = Indices<T>[number];

--- a/number/mod.ts
+++ b/number/mod.ts
@@ -1,0 +1,1 @@
+export * from "./types.ts";

--- a/number/types.ts
+++ b/number/types.ts
@@ -1,0 +1,84 @@
+import { Satisfies } from "../ts/types.ts";
+
+/** Maps `T` to a string literal type describing its number type.
+ * - `number` for `number`
+ * - `zero` for `0` and `-0` (TS cannot distinguish between them)
+ * - `+infinity` for `Infinity`
+ * - `-infinity` for `-Infinity`
+ * - `+float` for positive floating point numbers
+ * - `-float` for negative floating point numbers
+ * - `+integer` for positive integers
+ * - `-integer` for negative integers
+ *
+ * @example
+ * type Num = NumberType<number> // "number"
+ * type Zero = NumberType<0> // "zero"
+ * type NegZero = NumberType<-0> // "zero"
+ * type Inf = NumberType<1e999> // "+infinity"
+ * type NegInf = NumberType<-1e999> // "-infinity"
+ * type Flt = NumberType<1.1> // "+float"
+ * type NegFlt = NumberType<-1.1> // "-float"
+ * type Int = NumberType<1> // "+integer"
+ * type NegInt = NumberType<-1> // "-integer" */
+export type NumberType<T extends number> = T extends infer N //
+  ? number extends N // If `number` is `N`, then `T` is exactly `number`.
+    ? "number"
+  : N extends number // Otherwise, `T` is a specific number.
+    ? `${N}` extends `0` ? "zero" // All the rest is pattern matching.
+    : `${N}` extends `-${infer _}.${infer _}` ? "-float"
+    : `${N}` extends `${infer _}.${infer _}` ? "+float"
+    : `${N}` extends "Infinity" ? "+infinity"
+    : `${N}` extends "-Infinity" ? "-infinity"
+    : `${N}` extends `-${bigint}` ? "-integer"
+    : "+integer"
+  : never
+  : never;
+
+/** Returns `T` if it is `number`, `Infinity`, or `-Infinity`, otherwise
+ * `never`.
+ *
+ * @example
+ * type N = Wide<number> // number
+ * type F = Wide<1.1> // never
+ * type I = Wide<1> // never */
+export type Wide<T extends number> = NumberType<T> extends infer TName
+  ? TName extends "number" | "+infinity" | "-infinity" ? T
+  : never
+  : never;
+
+/** Returns `T` if it is an integer or float, otherwise `never`.
+ *
+ * @example
+ * type N = Finite<number> // never
+ * type F = Finite<1.1> // 1.1
+ * type I = Finite<1> // 1 */
+export type Finite<T extends number> = Satisfies<Wide<T>> extends true ? never
+  : T;
+
+/** Returns `T` if it is a float, otherwise `never`.
+ *
+ * @example
+ * type N = Float<number> // never
+ * type Flt = Float<1.1> // 1.1
+ * type NegFlt = Float<-1.1> // -1.1
+ * type Int = Float<1> // never */
+export type Float<T extends number> = NumberType<T> extends `${infer _}float`
+  ? T
+  : never;
+
+/** Returns `T` if it is an integer type, otherwise `never`.
+ *
+ * @example
+ * type Flt = Integer<1.1>; // never
+ * type Num = Integer<number> // never
+ * type Zero = Integer<0> // 0
+ * type NegZero = Integer<-0> // 0, TS cannot distinguish between 0 and -0
+ * type Int = Integer<1> // 1
+ * type NegInt = Integer<-1> // -1 */
+export type Integer<T extends number> = NumberType<T> extends
+  `${infer _}integer` | "zero" ? T
+  : never;
+
+export declare namespace Num {
+  export { Finite, Float, Integer, NumberType as Type, Wide };
+}

--- a/readme.md
+++ b/readme.md
@@ -49,6 +49,7 @@ type Indices = Tuple.Indices<["a", "b", "c"]>; // [0, 1, 2]
 type Index = Tuple.Index<["a", "b", "c"]>; // 0 | 1 | 2
 type Reversed = Tuple.Reverse<[1, 2, 3]>; // [3, 2, 1]
 type Deed = Tuple.FromIndices<["d", "e"], [0, 1, 1, 0]>; // ["d", "e", "e", "d"]
+type ThreeUnknowns = Tuple.OfLength<3>; // [unknown, unknown, unknown]
 ```
 
 ## `cli`

--- a/readme.md
+++ b/readme.md
@@ -308,11 +308,15 @@ await evaluate("console.log('Hello!')")
 ```
 
 ```ts
-import type { Pretty } from "https://deno.land/x/handy/ts/types.ts";
+import type { Pretty, Satisfies } from "https://deno.land/x/handy/ts/types.ts";
 
 type Input = { a: number } & { b: string };
 //     ^? { a: number } & { b: string }
 
 type Prettified = Pretty<Input>;
 //     ^? { a: number; b: string }
+
+type Str<T> = T extends string ? T : never;
+type T = Satisfies<Str<"ABC">>; // true
+type F = Satisfies<Str<123>>; // false
 ```

--- a/readme.md
+++ b/readme.md
@@ -322,6 +322,15 @@ sequences("A", "ABAACA"); // ["A", "AA", "A"]
 mostConsecutive("A", "ABAACA"); // 2
 ```
 
+```ts
+import { Str } from "https://deno.land/x/handy/string/types.ts";
+
+type Char = Str.Char<"ABC">; // "A" | "B" | "C"
+type Index = Str.Index<"ABC">; // 0 | 1 | 2
+type Indices = Str.Indices<"ABC">; // [0, 1, 2]
+type Tuple = Str.ToTuple<"ABC">; // ["A", "B", "C"]
+```
+
 ## `ts`
 
 TypeScript-related utilities.

--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,12 @@ mapOnInterval([3, 2, 1, "go!"], 100, (item) => console.log(item));
 ```
 
 ```ts
-import type { Tuple } from "https://deno.land/x/handy/array/types.ts";
+import type {
+  Tuple,
+  TypedArray,
+} from "https://deno.land/x/handy/array/types.ts";
+
+const arr: TypedArray = new Uint8Array();
 
 type Filled = Tuple.Fill<["a", "b"], 7>; // [7, 7]
 type Flattened = Tuple.Flat<[[1, 2], [3, 4]]>; // [1, 2, 3, 4]

--- a/readme.md
+++ b/readme.md
@@ -15,6 +15,7 @@ Utility functions, classes, types, and scripts in uncompiled TS, for Deno.
 - [`json`](#json)
 - [`md`](#md)
   - [`script/evalCodeBlocks`](#scriptevalcodeblocks)
+- [`number`](#number)
 - [`object`](#object)
 - [`os`](#os)
 - [`path`](#path)
@@ -235,6 +236,31 @@ deno run --allow-read --allow-run \
   https://deno.land/x/handy/scripts/evalCodeBlocks.ts \
   ./readme.md \
   "some string to find" "replacement string" # optional
+```
+
+## `number`
+
+Number-related utilities.
+
+```ts
+import { Num } from "https://deno.land/x/handy/number/types.ts";
+
+type T = Num.Type<1.1>; // "+float"
+type U = Num.Type<0>; // "zero"
+type V = Num.Type<-5>; // "-integer"
+
+// type filters return `never` if the type doesn't match
+type Finite = Num.Finite<0>; // 0
+type NotFinite = Num.Finite<number>; // never
+
+type Wide = Num.Wide<number>; // number
+type NotWide = Num.Wide<1>; // never
+
+type Int = Num.Integer<1>; // 1
+type NotInt = Num.Integer<1.1>; // never
+
+type Float = Num.Float<1.1>; // 1.1
+type NotFloat = Num.Float<1>; // never
 ```
 
 ## `object`

--- a/readme.md
+++ b/readme.md
@@ -80,6 +80,26 @@ largest("size", [new Set([1]), new Set([2, 3]), new Set()]); // new Set([2, 3])
 smallest("size", [new Set([1]), new Set([2, 3]), new Set()]); // new Set()
 ```
 
+```ts
+import {
+  Index,
+  IndexedCollection,
+  Indices,
+} from "https://deno.land/x/handy/collection/types.ts";
+
+const arr = ["a", "b", "c"] satisfies IndexedCollection;
+const str = "XY" satisfies IndexedCollection;
+const typedArr = new Uint8Array() satisfies IndexedCollection;
+
+type ArrIndices = Indices<typeof arr>; // [0, 1, 2]
+type StrIndices = Indices<typeof str>; // [0, 1]
+type TypedArrIndices = Indices<typeof typedArr>; // number[]
+
+type ArrIndex = Index<typeof arr>; // 0 | 1 | 2
+type StrIndex = Index<typeof str>; // 0 | 1
+type TypedArrIndex = Index<typeof typedArr>; // number
+```
+
 ## `fs`
 
 File system-related utilities.

--- a/string/mod.ts
+++ b/string/mod.ts
@@ -1,1 +1,2 @@
+export * from "./types.ts";
 export * from "./utils.ts";

--- a/string/types.ts
+++ b/string/types.ts
@@ -1,0 +1,42 @@
+import type { Tuple } from "../array/types.ts";
+
+/** Represents a tuple of the characters of `T`.
+ *
+ * @example
+ * type A = ToTuple<"abc"> // ["a", "b", "c"] */
+export type ToTuple<T extends string> = T extends `${infer Char}${infer Chars}`
+  ? [Char, ...ToTuple<Chars>]
+  : [];
+
+/** Represents one of the characters of `T`.
+ *
+ * @example
+ * type A = Char<"abcbca"> // "a" | "b" | "c" */
+export type Char<T extends string> = ToTuple<T>[number];
+
+/** Represents a tuple of the indices of `T`.
+ *
+ * @example
+ * type A = Indices<"abc"> // [0, 1, 2] */
+export type Indices<T extends string> = Tuple.Indices<ToTuple<T>>;
+
+/** Represents one of the indices of `T`.
+ *
+ * @example
+ * type A = Index<"abc"> // 0 | 1 | 2 */
+export type Index<T extends string> = Indices<T>[number];
+
+/** Returns `string` if `T` is exactly `string`, otherwise returns `never`.
+ *
+ * @example
+ * type A = Wide<string> // string
+ * type B = Wide<"abc"> // never */
+export type Wide<T extends string> = T extends infer U //
+  ? string extends U // If `string` is `U`...
+    ? string // then `T` is exactly `string`
+  : never
+  : never;
+
+export declare namespace Str {
+  export { Char, Index, Indices, ToTuple, Wide };
+}

--- a/ts/types.ts
+++ b/ts/types.ts
@@ -13,3 +13,11 @@
  * //   ^? { city: string, state: string, street: string, zip: string } */
 // deno-lint-ignore ban-types
 export type Pretty<T> = { [K in keyof T]: T[K] } & {};
+
+/** Returns `true` if `T` is not `never`, otherwise `false`. Useful in
+ * conditional types.
+ *
+ * @example
+ * type N = Satisfies<never> // false
+ * type Y = Satisfies<1> // true */
+export type Satisfies<T> = [T] extends [never] ? false : true;


### PR DESCRIPTION
Extracted from #97.

I recommend reading this one commit at a time.

It's all typedefs - no functions, so no unit tests.