### PR TITLE
test: simplify test cases and messages

### DIFF
--- a/_deps/testing.ts
+++ b/_deps/testing.ts
@@ -1,3 +1,5 @@
 export * from "https://deno.land/std@0.182.0/testing/asserts.ts";
 export * from "https://deno.land/std@0.182.0/testing/bdd.ts";
 export * from "https://deno.land/std@0.182.0/testing/mock.ts";
+
+export { it as test } from "https://deno.land/std@0.182.0/testing/bdd.ts";

--- a/array/mapOnInterval.test.ts
+++ b/array/mapOnInterval.test.ts
@@ -1,19 +1,17 @@
-import { assertEquals, describe, it } from "../_deps/testing.ts";
+import { assertEquals, test } from "../_deps/testing.ts";
 import { mapOnInterval } from "./mapOnInterval.ts";
 
-describe("array.mapOnInterval", () => {
-  it("works with synchronous predicates", async () =>
-    assertEquals(
-      await mapOnInterval(["a", "b"], 1, (l: string) => l.toUpperCase()),
-      ["A", "B"],
-    ));
+test("synchronous predicates", async () =>
+  assertEquals(
+    await mapOnInterval(["a", "b"], 1, (l: string) => l.toUpperCase()),
+    ["A", "B"],
+  ));
 
-  it("works with asynchronous predicates", async () => {
-    const asyncPredicate = async (l: string) => await l.toUpperCase();
+test("asynchronous predicates", async () => {
+  const asyncPredicate = async (l: string) => await l.toUpperCase();
 
-    assertEquals(
-      await mapOnInterval(["a", "b"], 1, asyncPredicate),
-      ["A", "B"],
-    );
-  });
+  assertEquals(
+    await mapOnInterval(["a", "b"], 1, asyncPredicate),
+    ["A", "B"],
+  );
 });

--- a/collection/largest.test.ts
+++ b/collection/largest.test.ts
@@ -1,26 +1,20 @@
-import { assertEquals, describe, it } from "../_deps/testing.ts";
+import { assertEquals, test } from "../_deps/testing.ts";
 import { largest } from "./largest.ts";
 
-describe("largest", () => {
-  it("finds longest strings in an Array", () => {
-    assertEquals(largest("length", ["a", "bbb", "cc", "ddd"]), ["bbb", "ddd"]);
-  });
+test("w/ Array", () =>
+  assertEquals(largest("length", ["a", "bbb", "cc", "ddd"]), ["bbb", "ddd"]));
 
-  it("finds longest strings in a Set", () => {
-    assertEquals(
-      largest("length", new Set(["a", "bbb", "cc", "ddd"])),
-      ["bbb", "ddd"],
-    );
-  });
+test("w/ Set", () =>
+  assertEquals(
+    largest("length", new Set(["a", "bbb", "cc", "ddd"])),
+    ["bbb", "ddd"],
+  ));
 
-  it("finds largest Set among Sets", () => {
-    assertEquals(
-      largest("size", [new Set([1, 2]), new Set([1, 2, 3])]),
-      [new Set([1, 2, 3])],
-    );
-  });
+test("w/ Array of Sets", () =>
+  assertEquals(
+    largest("size", [new Set([1, 2]), new Set([1, 2, 3])]),
+    [new Set([1, 2, 3])],
+  ));
 
-  it("handles length property specially", () => {
-    assertEquals(largest(["a", "bbb", "cc", "ddd"]), ["bbb", "ddd"]);
-  });
-});
+test(".length handling", () =>
+  assertEquals(largest(["a", "bbb", "cc", "ddd"]), ["bbb", "ddd"]));

--- a/collection/position.test.ts
+++ b/collection/position.test.ts
@@ -4,6 +4,7 @@ import {
   assertThrows,
   describe,
   it,
+  test,
 } from "../_deps/testing.ts";
 
 import * as position from "./position.ts";
@@ -83,22 +84,12 @@ describe("valid value handling", () => {
   });
 });
 
-describe("position.next", () => {
-  it("increments", () => {
-    assertEquals(position.next(0, [""]), 1);
-  });
-
-  it("returns null at the end", () => {
-    assertEquals(position.next(0, []), null);
-  });
+test("position.next", () => {
+  assertEquals(position.next(0, [""]), 1);
+  assertEquals(position.next(0, []), null);
 });
 
-describe("previous", () => {
-  it("decrements", () => {
-    assertEquals(position.previous(1), 0);
-  });
-
-  it("returns null at the end", () => {
-    assertEquals(position.previous(0), null);
-  });
+test(".previous", () => {
+  assertEquals(position.previous(1), 0);
+  assertEquals(position.previous(0), null);
 });

--- a/collection/smallest.test.ts
+++ b/collection/smallest.test.ts
@@ -1,26 +1,24 @@
-import { assertEquals, describe, it } from "../_deps/testing.ts";
+import { assertEquals, test } from "../_deps/testing.ts";
 import { smallest } from "./smallest.ts";
 
-describe("smallest", () => {
-  it("finds shortest strings in an Array", () => {
-    assertEquals(smallest("length", ["a", "bb", "c", "ddd"]), ["a", "c"]);
-  });
+test("Array of strings", () => {
+  assertEquals(smallest("length", ["a", "bb", "c", "ddd"]), ["a", "c"]);
+});
 
-  it("finds shortest strings in a Set", () => {
-    assertEquals(
-      smallest("length", new Set(["a", "bb", "c", "ddd"])),
-      ["a", "c"],
-    );
-  });
+test("Set of strings", () => {
+  assertEquals(
+    smallest("length", new Set(["a", "bb", "c", "ddd"])),
+    ["a", "c"],
+  );
+});
 
-  it("finds smallest Set from among Sets", () => {
-    assertEquals(
-      smallest("size", [new Set([1, 2]), new Set([1, 2, 3])]),
-      [new Set([1, 2])],
-    );
-  });
+test("Array of Sets", () => {
+  assertEquals(
+    smallest("size", [new Set([1, 2]), new Set([1, 2, 3])]),
+    [new Set([1, 2])],
+  );
+});
 
-  it("handles length property specially", () => {
-    assertEquals(smallest(["a", "bb", "c", "ddd"]), ["a", "c"]);
-  });
+test(".length handling", () => {
+  assertEquals(smallest(["a", "bb", "c", "ddd"]), ["a", "c"]);
 });

--- a/fs/findNearestFile.test.ts
+++ b/fs/findNearestFile.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from "../_deps/path.ts";
-import { assertEquals, assertRejects, describe, it } from "../_deps/testing.ts";
+import { assertEquals, assertRejects, test } from "../_deps/testing.ts";
 import { FIXTURE_DIR } from "../_test/constants.ts";
 import { findNearestFile } from "./findNearestFile.ts";
 
@@ -7,30 +7,28 @@ const A_DIR = resolve(FIXTURE_DIR, "fs", "a");
 const B_DIR = resolve(A_DIR, "b");
 const C_DIR = resolve(B_DIR, "c");
 
-describe("fs.findNearestFile", () => {
-  it("rejects a filepath", async () =>
-    void await assertRejects(() =>
-      findNearestFile(resolve(A_DIR, "findme.md"), "")
-    ));
+test("rejects a filepath", async () =>
+  void await assertRejects(() =>
+    findNearestFile(resolve(A_DIR, "findme.md"), "")
+  ));
 
-  it("locates nearest file by name", async () => {
-    assertEquals(
-      await findNearestFile(A_DIR, "findme.md"),
-      resolve(A_DIR, "findme.md"),
-    );
-    assertEquals(
-      await findNearestFile(B_DIR, "findme.md"),
-      resolve(A_DIR, "findme.md"),
-    );
-    assertEquals(
-      await findNearestFile(C_DIR, "findme.md"),
-      resolve(C_DIR, "findme.md"),
-    );
-  });
-
-  it("falls back to undefined", async () =>
-    assertEquals(
-      await findNearestFile(FIXTURE_DIR, "findme.md"),
-      undefined,
-    ));
+test("locates nearest file", async () => {
+  assertEquals(
+    await findNearestFile(A_DIR, "findme.md"),
+    resolve(A_DIR, "findme.md"),
+  );
+  assertEquals(
+    await findNearestFile(B_DIR, "findme.md"),
+    resolve(A_DIR, "findme.md"),
+  );
+  assertEquals(
+    await findNearestFile(C_DIR, "findme.md"),
+    resolve(C_DIR, "findme.md"),
+  );
 });
+
+test("falls back to undefined", async () =>
+  assertEquals(
+    await findNearestFile(FIXTURE_DIR, "findme.md"),
+    undefined,
+  ));

--- a/fs/glob.test.ts
+++ b/fs/glob.test.ts
@@ -1,5 +1,5 @@
 import { resolve } from "../_deps/path.ts";
-import { assertArrayIncludes, describe, it } from "../_deps/testing.ts";
+import { assertArrayIncludes, it } from "../_deps/testing.ts";
 import { glob } from "./glob.ts";
 import { FIXTURE_DIR } from "../_test/constants.ts";
 
@@ -11,6 +11,5 @@ const C_DIR = resolve(A_DIR, "b", "c");
 const A_FILE = resolve(A_DIR, "findme.ts");
 const C_FILE = resolve(C_DIR, "findme.ts");
 
-describe("fs.glob", () =>
-  it("finds files matching the pattern", async () =>
-    assertArrayIncludes(await glob(GLOB), [A_FILE, C_FILE])));
+it("finds files matching the pattern", async () =>
+  assertArrayIncludes(await glob(GLOB), [A_FILE, C_FILE]));

--- a/git/commit/conventional.test.ts
+++ b/git/commit/conventional.test.ts
@@ -3,6 +3,7 @@ import {
   assertThrows,
   describe,
   it,
+  test,
 } from "../../_deps/testing.ts";
 import { dedent } from "../../string/dedent.ts";
 import {
@@ -23,7 +24,7 @@ describe("parse", () => {
   describe("official examples", () => {
     // https://www.conventionalcommits.org/en/v1.0.0/#examples
 
-    it("handles #1", () =>
+    test("example #1", () =>
       assertEquals(
         parse(msg(`
         feat: allow provided config object to extend other configs
@@ -41,7 +42,7 @@ describe("parse", () => {
         },
       ));
 
-    it("handles #2", () =>
+    test("example #2", () =>
       assertEquals(
         parse("feat!: send an email to the customer when a product is shipped"),
         {
@@ -52,7 +53,7 @@ describe("parse", () => {
         },
       ));
 
-    it("handles #3", () =>
+    test("example #3", () =>
       assertEquals(
         parse(
           "feat(api)!: send an email to the customer when a product is shipped",
@@ -66,7 +67,7 @@ describe("parse", () => {
         },
       ));
 
-    it("handles #4", () =>
+    test("example #4", () =>
       assertEquals(
         parse(msg(`
           chore!: drop support for Node 6
@@ -84,7 +85,7 @@ describe("parse", () => {
         },
       ));
 
-    it("handles #5", () =>
+    test("example #5", () =>
       assertEquals(
         parse("docs: correct spelling of CHANGELOG"),
         {
@@ -93,7 +94,7 @@ describe("parse", () => {
         },
       ));
 
-    it("handles #6", () =>
+    test("example #6", () =>
       assertEquals(
         parse("feat(lang): add Polish language"),
         {
@@ -103,7 +104,7 @@ describe("parse", () => {
         },
       ));
 
-    it("handles #7", () =>
+    test("example #7", () =>
       assertEquals(
         parse(msg(`
         fix: prevent racing of requests
@@ -131,8 +132,8 @@ describe("parse", () => {
       ));
   });
 
-  describe("common usage", () => {
-    it("handles magic comments", () =>
+  describe("special footers", () => {
+    test("magic comments", () =>
       assertEquals(
         parse(msg(`
           fix: prevent racing of requests
@@ -145,7 +146,7 @@ describe("parse", () => {
         },
       ));
 
-    it("handles BREAKING-CHANGE", () =>
+    test("BREAKING-CHANGE", () =>
       assertEquals(
         parse(msg(`
         fix: do something
@@ -175,7 +176,7 @@ describe("parse", () => {
         },
       ));
 
-    it("trims lines", () =>
+    test("trims lines", () =>
       assertEquals(
         parse(msg(`
             refactor: whatever
@@ -192,7 +193,7 @@ describe("parse", () => {
   });
 
   describe("complex bodies", () => {
-    it("doesn't ruin them", () =>
+    it("preserves them", () =>
       assertEquals(
         parse(msg(`
             test: this
@@ -235,25 +236,25 @@ describe("parse", () => {
 });
 
 describe("stringify", () => {
-  it("handles scope", () =>
+  test("scope", () =>
     assertEquals(
       stringify({ type: "feat", scope: "lang", description: "add Polish" }),
       "feat(lang): add Polish",
     ));
 
-  it("handles breakingChange", () =>
+  test("breakingChange", () =>
     assertEquals(
       stringify({ type: "feat", description: "oops", breakingChange: true }),
       "feat!: oops",
     ));
 
-  it("handles body", () =>
+  test("body", () =>
     assertEquals(
       stringify({ type: "feat", body: "XXX", description: "whatever" }),
       "feat: whatever\n\nXXX",
     ));
 
-  it("preserves body format", () =>
+  test("body", () =>
     assertEquals(
       stringify({ type: "feat", body: "XXX\n  \nYY", description: "whatever" }),
       "feat: whatever\n\nXXX\n  \nYY",
@@ -323,44 +324,44 @@ describe("stringify", () => {
       `),
     ));
 
-  describe("validation", () => {
-    it('throws on "" type', () =>
+  describe("validation: throwing", () => {
+    test('"" type', () =>
       void assertThrows(
         () => stringify({ type: "", description: "bar" }),
         ConventionalTypeError,
       ));
 
-    it("throws on \\n in type", () =>
+    test("\\n in type", () =>
       void assertThrows(
         () => stringify({ type: "a\nb", description: "bar" }),
         ConventionalTypeError,
       ));
 
-    it('throws on "" scope', () =>
+    test('"" scope', () =>
       void assertThrows(
         () => stringify({ type: "feat", scope: "", description: "bar" }),
         ConventionalScopeError,
       ));
 
-    it("throws on \\n in scope", () =>
+    test("\\n in scope", () =>
       void assertThrows(
         () => stringify({ type: "feat", scope: "a\nb", description: "bar" }),
         ConventionalScopeError,
       ));
 
-    it('throws on "" desc', () =>
+    test('"" desc', () =>
       void assertThrows(
         () => stringify({ type: "feat", description: "a\nb" }),
         ConventionalDescriptionError,
       ));
 
-    it("throws on \\n in desc", () =>
+    test("\\n in desc", () =>
       void assertThrows(
         () => stringify({ type: "feat", description: "a\nb" }),
         ConventionalDescriptionError,
       ));
 
-    it('throws on "" footer key', () =>
+    test('"" footer key', () =>
       void assertThrows(
         () =>
           stringify({
@@ -371,7 +372,7 @@ describe("stringify", () => {
         ConventionalFooterError,
       ));
 
-    it("throws on \\n footer key", () =>
+    test("\\n footer key", () =>
       void assertThrows(
         () =>
           stringify({

--- a/git/commit/get.test.ts
+++ b/git/commit/get.test.ts
@@ -6,6 +6,7 @@ import {
   beforeAll,
   describe,
   it,
+  test,
 } from "../../_deps/testing.ts";
 import { _internals } from "../../_test/_internals.ts";
 import { CmdStub, stubCmd } from "../../cli/cmd.stub.ts";
@@ -61,8 +62,7 @@ describe("describe", () => {
       message: "feat(io/clipboard): init; add `copy()` & `paste()`",
     }));
 
-  it("throws if the input is invalid", () =>
-    void assertThrows(() => _describe("")));
+  it("throws on invalid input", () => void assertThrows(() => _describe("")));
 });
 
 describe("get", () => {
@@ -84,13 +84,13 @@ describe("get", () => {
   it("describes a commit", async () =>
     assertEquals(await get("aaa"), commitDescriptions.aaa));
 
-  it("throws if commit not found", async () =>
+  it("throws w/o commit found", async () =>
     void await assertRejects(() => get("XXX")));
 
-  it("throws if a span is passed", async () =>
+  it("throws if given a span", async () =>
     void await assertRejects(() => get("aaa..bbb")));
 
-  it("throws if a space is passed", async () =>
+  it("throws if given a space", async () =>
     void await assertRejects(() => get("aaa bbb")));
 
   afterAll(() => cmdStub.restore());
@@ -132,23 +132,23 @@ describe("getSpan", () => {
     });
   });
 
-  it("throws if start not found", async () =>
+  it("throws w/o start", async () =>
     void await assertRejects(() => getSpan(["XXX", "bbb"])));
 
-  it("throws if end not found", async () =>
+  it("throws w/o end", async () =>
     void await assertRejects(() => getSpan(["aaa", "XXX"])));
 
   describe("without opts.inclusive", () => {
-    it("describes a span of commits", async () =>
+    it("describes commit span", async () =>
       assertEquals(await getSpan(["aaa", "ccc"]), [
         _describe(commits.bbb),
         _describe(commits.ccc),
       ]));
 
-    it("returns [] when equal", async () =>
+    test("[] when equal", async () =>
       assertEquals(await getSpan(["bbb", "bbb"]), []));
 
-    it("returns [] when end > start", async () =>
+    test("[] when end > start", async () =>
       assertEquals(await getSpan(["bbb", "aaa"]), []));
 
     it("understands HEAD", async () =>
@@ -158,18 +158,18 @@ describe("getSpan", () => {
   });
 
   describe("with opts.inclusive", () => {
-    it("describes a span of commits", async () =>
+    it("describes commit span", async () =>
       assertEquals(await getSpan(["aaa", "bbb"], { inclusive: true }), [
         _describe(commits.aaa),
         _describe(commits.bbb),
       ]));
 
-    it("returns [start] when equal", async () =>
+    test("[start] when equal", async () =>
       assertEquals(await getSpan(["bbb", "bbb"], { inclusive: true }), [
         _describe(commits.bbb),
       ]));
 
-    it("returns [] when start > end", async () =>
+    test("[] when start > end", async () =>
       assertEquals(await getSpan(["bbb", "aaa"], { inclusive: true }), []));
 
     it("understands HEAD", async () =>

--- a/git/script/makeReleaseNotes.test.ts
+++ b/git/script/makeReleaseNotes.test.ts
@@ -1,10 +1,4 @@
-import {
-  afterAll,
-  assertEquals,
-  beforeAll,
-  describe,
-  it,
-} from "../../_deps/testing.ts";
+import { afterAll, assertEquals, beforeAll, it } from "../../_deps/testing.ts";
 import { _internals } from "../../_test/_internals.ts";
 import { CmdStub, stubCmd } from "../../cli/cmd.stub.ts";
 import { dedent } from "../../string/dedent.ts";
@@ -49,17 +43,16 @@ const commits: Record<string, string> = {
 const commitsConcat =
   `${commits.aaa}\n\n${commits.bbb}\n\n${commits.ccc}\n\n${commits.ddd}`;
 
-describe("makeReleaseNotes", () => {
-  let cmdStub: CmdStub;
+let cmdStub: CmdStub;
 
-  beforeAll(() => {
-    cmdStub = stubCmd(_internals, () => commitsConcat);
-  });
+beforeAll(() => {
+  cmdStub = stubCmd(_internals, () => commitsConcat);
+});
 
-  it("puts breaking changes first", async () =>
-    assertEquals(
-      await makeReleaseNotes(),
-      dedent(`
+it("has breaking changes 1st", async () =>
+  assertEquals(
+    await makeReleaseNotes(),
+    dedent(`
         * **Breaking Change** fix(cli): unbreak all the things (bbb)
         
         * **Breaking Change** move: \`scripts/evalCodeBlocks\` -> \`md/scripts/evalCodeBlocks\` (ccc)
@@ -76,12 +69,12 @@ describe("makeReleaseNotes", () => {
 
         * fix: unbreak a new thing (ddd)
       `).trim(),
-    ));
+  ));
 
-  it("can group by type", async () =>
-    assertEquals(
-      await makeReleaseNotes({ groupByType: true }),
-      dedent(`
+it("can group by type", async () =>
+  assertEquals(
+    await makeReleaseNotes({ groupByType: true }),
+    dedent(`
         ## Features
         
         * (io/clipboard): init; add \`copy()\` & \`paste()\` (aaa)
@@ -104,59 +97,58 @@ describe("makeReleaseNotes", () => {
         
         * **Breaking Change**: \`scripts/evalCodeBlocks\` -> \`md/scripts/evalCodeBlocks\` (ccc)
       `).trim(),
-    ));
+  ));
 
-  it("can filter types", async () =>
-    assertEquals(
-      await makeReleaseNotes({ types: ["fix", "move"] }),
-      dedent(`
+it("can filter types", async () =>
+  assertEquals(
+    await makeReleaseNotes({ types: ["fix", "move"] }),
+    dedent(`
         * **Breaking Change** fix(cli): unbreak all the things (bbb)
 
         * **Breaking Change** move: \`scripts/evalCodeBlocks\` -> \`md/scripts/evalCodeBlocks\` (ccc)
 
         * fix: unbreak a new thing (ddd)
       `).trim(),
-    ));
+  ));
 
-  it("can order types", async () =>
-    assertEquals(
-      await makeReleaseNotes({ types: ["move", "fix"] }),
-      dedent(`
+it("can order types", async () =>
+  assertEquals(
+    await makeReleaseNotes({ types: ["move", "fix"] }),
+    dedent(`
         * **Breaking Change** move: \`scripts/evalCodeBlocks\` -> \`md/scripts/evalCodeBlocks\` (ccc)
 
         * **Breaking Change** fix(cli): unbreak all the things (bbb)
 
         * fix: unbreak a new thing (ddd)
       `).trim(),
-    ));
+  ));
 
-  it("can name type groups", async () =>
-    assertEquals(
-      await makeReleaseNotes({
-        types: ["move"],
-        groupByType: true,
-        typeNames: { move: "Moved Files" },
-      }),
-      dedent(`
+it("can name type groups", async () =>
+  assertEquals(
+    await makeReleaseNotes({
+      types: ["move"],
+      groupByType: true,
+      typeNames: { move: "Moved Files" },
+    }),
+    dedent(`
         ## Moved Files
       
         * **Breaking Change**: \`scripts/evalCodeBlocks\` -> \`md/scripts/evalCodeBlocks\` (ccc)
       `).trim(),
-    ));
+  ));
 
-  it("skips empty type groups", async () =>
-    assertEquals(
-      await makeReleaseNotes({
-        types: ["move", "foo"],
-        groupByType: true,
-        typeNames: { move: "Moved Files" },
-      }),
-      dedent(`
+it("skips empty type groups", async () =>
+  assertEquals(
+    await makeReleaseNotes({
+      types: ["move", "foo"],
+      groupByType: true,
+      typeNames: { move: "Moved Files" },
+    }),
+    dedent(`
         ## Moved Files
       
         * **Breaking Change**: \`scripts/evalCodeBlocks\` -> \`md/scripts/evalCodeBlocks\` (ccc)
       `).trim(),
-    ));
+  ));
 
-  afterAll(() => cmdStub.restore());
-});
+afterAll(() => cmdStub.restore());

--- a/git/tag.test.ts
+++ b/git/tag.test.ts
@@ -42,7 +42,7 @@ describe("getLatest", () => {
     );
   });
 
-  it("finds the alphabetically last tag", async () =>
+  it("gets alphabetic last tag", async () =>
     assertEquals(await getLatest(), "0.2.0"));
 
   it("accepts a directory", async () =>

--- a/graph/DirectedGraph.test.ts
+++ b/graph/DirectedGraph.test.ts
@@ -6,371 +6,371 @@ import {
   beforeEach,
   describe,
   it,
+  test,
 } from "../_deps/testing.ts";
 import { DirectedGraph } from "./DirectedGraph.ts";
 import { VertexError } from "./errors.ts";
 
-describe("DirectedGraph", () => {
-  let graph: DirectedGraph<string>;
+let graph: DirectedGraph<string>;
 
-  function assertVertices(
-    graph: DirectedGraph<string>,
-    ...vertices: string[]
-  ): void {
-    assertEquals(graph.vertices, new Set(vertices));
-  }
+function assertVertices(
+  graph: DirectedGraph<string>,
+  ...vertices: string[]
+): void {
+  assertEquals(graph.vertices, new Set(vertices));
+}
 
-  function assertEdges(
-    graph: DirectedGraph<string>,
-    ...edges: [string, string][]
-  ): void {
-    assertEquals(graph.edges, new Set(edges));
-  }
+function assertEdges(
+  graph: DirectedGraph<string>,
+  ...edges: [string, string][]
+): void {
+  assertEquals(graph.edges, new Set(edges));
+}
 
-  beforeEach(() => {
-    graph = new DirectedGraph();
+beforeEach(() => {
+  graph = new DirectedGraph();
+});
+
+describe("namespace", () => {
+  it("includes related types", () => {
+    const _vertex: DirectedGraph.Vertex<string> = "a";
+    const _vertices: DirectedGraph.Vertices<string> = new Set("a");
+    const _edge: DirectedGraph.Edge<string> = ["a", "b"];
+    const _path: DirectedGraph.Path<string> = ["a", "b", "c"];
+    const _visitor: DirectedGraph.Visitor<string, void> = () => {};
+    const _options: DirectedGraph.WalkOptions = { includeSource: true };
   });
+});
 
-  describe("namespace", () => {
-    it("includes its related types", () => {
-      const _vertex: DirectedGraph.Vertex<string> = "a";
-      const _vertices: DirectedGraph.Vertices<string> = new Set("a");
-      const _edge: DirectedGraph.Edge<string> = ["a", "b"];
-      const _path: DirectedGraph.Path<string> = ["a", "b", "c"];
-      const _visitor: DirectedGraph.Visitor<string, void> = () => {};
-      const _options: DirectedGraph.WalkOptions = { includeSource: true };
-    });
+describe("constructor", () => {
+  it("can clone a graph", () => {
+    graph.add(["a", "b"]);
+    const clone = new DirectedGraph(graph);
+    assertVertices(clone, "a", "b");
+    assertEdges(clone, ["a", "b"]);
+
+    clone.remove("a");
+    assertVertices(graph, "a", "b");
+    assertVertices(clone, "b");
+
+    clone.add(["c", "d"]);
+    assertVertices(graph, "a", "b");
+    assertEdges(graph, ["a", "b"]);
+    assertVertices(clone, "b", "c", "d");
+    assertEdges(clone, ["c", "d"]);
   });
+});
 
-  describe("constructor", () => {
-    it("can clone a graph", () => {
-      graph.add(["a", "b"]);
-      const clone = new DirectedGraph(graph);
-      assertVertices(clone, "a", "b");
-      assertEdges(clone, ["a", "b"]);
+describe("properties", () => {
+  test("vertices", () => assert(graph.vertices instanceof Set));
 
-      clone.remove("a");
-      assertVertices(graph, "a", "b");
-      assertVertices(clone, "b");
+  test("edges", () => assert(graph.edges instanceof Set));
 
-      clone.add(["c", "d"]);
-      assertVertices(graph, "a", "b");
-      assertEdges(graph, ["a", "b"]);
-      assertVertices(clone, "b", "c", "d");
-      assertEdges(clone, ["c", "d"]);
-    });
-  });
-
-  describe("properties", () => {
-    it("has vertices", () => assert(graph.vertices instanceof Set));
-
-    it("has edges", () => assert(graph.edges instanceof Set));
-
-    it("has root vertices", () => {
-      graph.add(["a", "b", "c", "d"]);
-      assertEquals(graph.roots, new Set("a"));
-    });
-
-    it("has leaf vertices", () => {
-      graph.add(["a", "b", "c", "d"]);
-      assertEquals(graph.leaves, new Set(["d"]));
-    });
-
-    it("can tell if it's cyclic", () => {
-      graph.add(["a", "b", "c", "d"]);
-      assert(!graph.isCyclic);
-
-      assert(new DirectedGraph(graph).add(["d", "a"]).isCyclic);
-      assert(new DirectedGraph(graph).add(["d", "c"]).isCyclic);
-      assert(new DirectedGraph(graph).add(["d", "b"]).isCyclic);
-      assert(new DirectedGraph<string>().add(["y", "z", "y"]).isCyclic);
-      assert(!new DirectedGraph(graph).add(["a", "c"]).isCyclic);
-    });
-
-    it("can tell if it's a tree", () => {
-      graph.add(["a", "b", "c", "d"], ["a", "e"], ["b", "f"]);
-      assert(graph.isTree);
-
-      assert(!new DirectedGraph(graph).add(["d", "a"]).isTree);
-      assert(!new DirectedGraph(graph).add(["a", "c"]).isTree);
-      assert(!new DirectedGraph(graph).add(["y", "z", "y"]).isTree);
-    });
-
-    it("can tell if it's a forest", () => {
-      graph.add(["a", "b", "c", "d"], ["h", "i"], ["v", "w", "x"]);
-      assert(graph.isForest);
-
-      assert(!new DirectedGraph(graph).add(["b", "i"]).isForest);
-      assert(new DirectedGraph(graph).add(["x", "h"]).isForest);
-      assert(new DirectedGraph(graph).add(["d", "v"]).isForest);
-    });
-
-    it("has custom console.log output", () => {
-      graph.add(["a", "b", "c", "d"]);
-      assertEquals(Deno.inspect(graph), "DirectedGraph(4 vertices, 3 edges)");
-    });
-
-    it("is iterable, yielding vertices", () => {
-      graph.add(["a", "b", "c", "d"]);
-      assertEquals([...graph], ["a", "b", "c", "d"]);
-    });
-  });
-
-  it("has chainable add/remove methods", () =>
-    assert(graph.add("a").remove("a") === graph));
-
-  describe("graph.has()", () => {
-    it("accepts a vertex", () => {
-      assert(!graph.has("a"));
-      assert(graph.add("a").has("a"));
-    });
-
-    it("accepts an edge", () => {
-      assert(!graph.has(["a", "b"]));
-      assert(graph.add(["a", "b"]).has(["a", "b"]));
-    });
-
-    it("accepts a path", () => {
-      assert(!graph.has(["a", "b", "c", "d"]));
-      assert(graph.add(["a", "b", "c", "d"]).has(["a", "b", "c", "d"]));
-    });
-
-    it("treats a single-element path as a vertex", () => {
-      assert(graph.add("a").has(["a"]));
-    });
-
-    it("accepts multiple inputs", () => {
-      assert(!graph.has(["a", "b"], "c", ["d", "e", "f"]));
-      assert(
-        graph.add(["a", "b"], "c", ["d", "e", "f"])
-          .has(["a", "b"], "c", ["d", "e", "f"]),
-      );
-    });
-  });
-
-  describe("graph.add()", () => {
-    it("adds vertices", () => assert(graph.add("a").has("a")));
-
-    it("adds edges", () => {
-      graph.add(["a", "b"], ["a", "c"]);
-      assertVertices(graph, "a", "b", "c");
-      assertEdges(graph, ["a", "b"], ["a", "c"]);
-    });
-
-    it("deduplicates edges", () => {
-      graph.add(["a", "b"], ["a", "b"]);
-      assertVertices(graph, "a", "b");
-      assertEdges(graph, ["a", "b"]);
-    });
-
-    it("adds paths", () => {
-      graph.add(["a", "b", "c"]);
-      assertVertices(graph, "a", "b", "c");
-      assertEdges(graph, ["a", "b"], ["b", "c"]);
-    });
-
-    it("treats a single-element path as a vertex", () => {
-      graph.add(["a"]);
-      assertVertices(graph, "a");
-      assertEdges(graph);
-    });
-
-    it("handles multiple inputs", () => {
-      graph.add(["a", "b"], "c", ["d", "e", "f"]);
-      assertVertices(graph, "a", "b", "c", "d", "e", "f");
-      assertEdges(graph, ["a", "b"], ["d", "e"], ["e", "f"]);
-    });
-  });
-
-  describe("graph.remove()", () => {
-    it("removes vertices", () => {
-      assert(graph.add("a").has("a"));
-      assert(!graph.remove("a").has("a"));
-    });
-
-    it("removes edges", () => {
-      graph.add(["a", "b"]).remove(["a", "b"]);
-      assertVertices(graph, "a", "b");
-      assertEdges(graph);
-    });
-
-    it("removes paths", () => {
-      graph.add(["a", "b", "c", "d", "e"]).remove(["b", "c", "d"]);
-      assertVertices(graph, "a", "b", "c", "d", "e");
-      assertEdges(graph, ["a", "b"], ["d", "e"]);
-    });
-
-    it("ignores single-element paths", () => {
-      graph.add(["a", "b", "c"]).remove(["b"]);
-      assertVertices(graph, "a", "b", "c");
-      assertEdges(graph, ["a", "b"], ["b", "c"]);
-    });
-
-    it("removes mixed inputs", () => {
-      graph.add(["a", "b", "c", "d", "e"], "f").remove(["a", "b", "c"], "e");
-      assertVertices(graph, "a", "b", "c", "d", "f");
-      assertEdges(graph, ["c", "d"]);
-    });
-
-    it("removes edges of a removed vertex", () => {
-      graph.add(["a", "b"], ["a", "c"]).remove("a");
-      assertVertices(graph, "b", "c");
-      assertEdges(graph);
-    });
-  });
-
-  it("returns new vertices and edges", () => {
-    const vertices = graph.add(["a", "b"]).vertices;
-    vertices.delete("a");
-    assert(graph.has("a"));
-    assert(!vertices.has("a"));
-
-    const edgesFromA = graph.edgesFrom("a");
-    edgesFromA.delete("b");
-    assert(graph.edgesFrom("a").has("b"));
-    assert(!edgesFromA.has("b"));
-  });
-
-  it("throws custom error on absent vertex", () => {
-    assertThrows(() => graph.remove("a"), VertexError, " a");
-    assertThrows(() => graph.remove("z"), VertexError, " z");
-    assertThrows(() => graph.edgesFrom("q"), VertexError, " q");
-    assertThrows(() => graph.edgesFrom("x"), VertexError, " x");
-    assertThrows(() => graph.hasCycle("w"), VertexError, " w");
-    assertThrows(() => graph.subgraph(["a"]), VertexError, " a");
-  });
-
-  describe("graph.walk", () => {
-    it("traverses depth-first", () => {
-      graph.add(["a", "b", "e"], ["a", "c"], ["a", "d"], ["b", "f"]);
-      const visited: string[] = [];
-      graph.walk("a", (vertex) => void visited.push(vertex));
-      assertEquals(visited, ["b", "e", "f", "c", "d"]);
-    });
-
-    it("can walk in reverse", () => {
-      graph.add(["a", "z"], ["b", "z"], ["c", "z"]);
-      const visited: string[] = [];
-      graph.walk("z", (vertex) => void visited.push(vertex), { reverse: true });
-      assertEquals(visited, ["a", "b", "c"]);
-    });
-
-    it("can return a value", () => {
-      graph.add(["a", "b"], ["a", "c"], ["a", "d"]);
-      const visited: string[] = [];
-      const result = graph
-        .walk("a", (v) => v === "c" ? "stopped at c!" : void visited.push(v));
-      assertEquals(visited, ["b"]);
-      assertEquals(result, "stopped at c!");
-    });
-
-    it("can visit the source vertex", () => {
-      graph.add(["a", "b"], ["a", "c"], ["a", "d"]);
-      const visited: string[] = [];
-      graph.walk(
-        "a",
-        (vertex) => void visited.push(vertex),
-        { includeSource: true },
-      );
-      assertEquals(visited, ["a", "b", "c", "d"]);
-    });
-
-    it("can traverse breadth-first", () => {
-      graph.add(["a", "b", "e"], ["a", "c"], ["a", "d"], ["b", "f"]);
-      const visited: string[] = [];
-      graph.walk("a", (v) => void visited.push(v), { breadthFirst: true });
-      assertEquals(visited, ["b", "c", "d", "e", "f"]);
-    });
-
-    it("skips visited vertices", () => {
-      graph.add(["a", "b", "a"]);
-      const visited: string[] = [];
-      graph.walk("a", (v) => void visited.push(v));
-      assertEquals(visited, ["b"]);
-    });
-
-    it("can revisit vertices", () => {
-      graph.add(["a", "b", "a"]);
-      const visited: string[] = [];
-      graph.walk(
-        "a",
-        (v) => visited.push(v) > 8 ? "stop" : undefined,
-        { skipVisited: false },
-      );
-      assertEquals(visited, ["b", "a", "b", "a", "b", "a", "b", "a", "b"]);
-
-      const visited2: string[] = [];
-      graph.walk(
-        "a",
-        (v) => visited2.push(v) > 8 ? "stop" : undefined,
-        { skipVisited: false, breadthFirst: true },
-      );
-      assertEquals(visited2, ["b", "a", "b", "a", "b", "a", "b", "a", "b"]);
-    });
-  });
-
-  it("finds paths between vertices", () => {
+  test("roots", () => {
     graph.add(["a", "b", "c", "d"]);
-    assertEquals(graph.paths("a", "b"), [["a", "b"]]);
-    assertEquals(graph.paths("a", "c"), [["a", "b", "c"]]);
-    assertEquals(graph.paths("a", "d"), [["a", "b", "c", "d"]]);
+    assertEquals(graph.roots, new Set("a"));
+  });
+
+  test("leaves", () => {
+    graph.add(["a", "b", "c", "d"]);
+    assertEquals(graph.leaves, new Set(["d"]));
+  });
+
+  test("isCyclic", () => {
+    graph.add(["a", "b", "c", "d"]);
+    assert(!graph.isCyclic);
+
+    assert(new DirectedGraph(graph).add(["d", "a"]).isCyclic);
+    assert(new DirectedGraph(graph).add(["d", "c"]).isCyclic);
+    assert(new DirectedGraph(graph).add(["d", "b"]).isCyclic);
+    assert(new DirectedGraph<string>().add(["y", "z", "y"]).isCyclic);
+    assert(!new DirectedGraph(graph).add(["a", "c"]).isCyclic);
+  });
+
+  test("isTree", () => {
+    graph.add(["a", "b", "c", "d"], ["a", "e"], ["b", "f"]);
+    assert(graph.isTree);
+
+    assert(!new DirectedGraph(graph).add(["d", "a"]).isTree);
+    assert(!new DirectedGraph(graph).add(["a", "c"]).isTree);
+    assert(!new DirectedGraph(graph).add(["y", "z", "y"]).isTree);
+  });
+
+  test("isForest", () => {
+    graph.add(["a", "b", "c", "d"], ["h", "i"], ["v", "w", "x"]);
+    assert(graph.isForest);
+
+    assert(!new DirectedGraph(graph).add(["b", "i"]).isForest);
+    assert(new DirectedGraph(graph).add(["x", "h"]).isForest);
+    assert(new DirectedGraph(graph).add(["d", "v"]).isForest);
+  });
+
+  test("custom inspect", () => {
+    graph.add(["a", "b", "c", "d"]);
+    assertEquals(Deno.inspect(graph), "DirectedGraph(4 vertices, 3 edges)");
+  });
+
+  test("iterator of vertices", () => {
+    graph.add(["a", "b", "c", "d"]);
+    assertEquals([...graph], ["a", "b", "c", "d"]); // yields vertices
+  });
+});
+
+it("has chainable methods", () => assert(graph.add("a").remove("a") === graph));
+
+describe("graph.has()", () => {
+  test("vertex", () => {
+    assert(!graph.has("a"));
+    assert(graph.add("a").has("a"));
+  });
+
+  test("edge", () => {
+    assert(!graph.has(["a", "b"]));
+    assert(graph.add(["a", "b"]).has(["a", "b"]));
+  });
+
+  test("path", () => {
+    assert(!graph.has(["a", "b", "c", "d"]));
+    assert(graph.add(["a", "b", "c", "d"]).has(["a", "b", "c", "d"]));
+  });
+
+  test("length-1 path", () => {
+    assert(graph.add("a").has(["a"])); // treat as vertex only
+  });
+
+  test("mixed inputs", () => {
+    assert(!graph.has(["a", "b"], "c", ["d", "e", "f"]));
+    assert(
+      graph.add(["a", "b"], "c", ["d", "e", "f"])
+        .has(["a", "b"], "c", ["d", "e", "f"]),
+    );
+  });
+});
+
+describe("graph.add()", () => {
+  test("vertices", () => assert(graph.add("a").has("a")));
+
+  test("edges", () => {
+    graph.add(["a", "b"], ["a", "c"]);
+    assertVertices(graph, "a", "b", "c");
+    assertEdges(graph, ["a", "b"], ["a", "c"]);
+  });
+
+  it("deduplicates edges", () => {
+    graph.add(["a", "b"], ["a", "b"]);
+    assertVertices(graph, "a", "b");
+    assertEdges(graph, ["a", "b"]);
+  });
+
+  test("paths", () => {
+    graph.add(["a", "b", "c"]);
+    assertVertices(graph, "a", "b", "c");
+    assertEdges(graph, ["a", "b"], ["b", "c"]);
+  });
+
+  test("length-1 paths", () => {
+    graph.add(["a"]);
+    assertVertices(graph, "a");
+    assertEdges(graph); // treated as vertex only
+  });
+
+  test(" mixed inputs", () => {
+    graph.add(["a", "b"], "c", ["d", "e", "f"]);
+    assertVertices(graph, "a", "b", "c", "d", "e", "f");
+    assertEdges(graph, ["a", "b"], ["d", "e"], ["e", "f"]);
+  });
+});
+
+describe("graph.remove()", () => {
+  test("vertices", () => {
+    assert(graph.add("a").has("a"));
+    assert(!graph.remove("a").has("a"));
+  });
+
+  test("edges", () => {
+    graph.add(["a", "b"]).remove(["a", "b"]);
+    assertVertices(graph, "a", "b");
+    assertEdges(graph);
+  });
+
+  test("paths", () => {
+    graph.add(["a", "b", "c", "d", "e"]).remove(["b", "c", "d"]);
+    assertVertices(graph, "a", "b", "c", "d", "e");
+    assertEdges(graph, ["a", "b"], ["d", "e"]);
+  });
+
+  test("length-1 paths", () => {
+    graph.add(["a", "b", "c"]).remove(["b"]);
+    assertVertices(graph, "a", "b", "c");
+    assertEdges(graph, ["a", "b"], ["b", "c"]);
+  });
+
+  test("mixed inputs", () => {
+    graph.add(["a", "b", "c", "d", "e"], "f").remove(["a", "b", "c"], "e");
+    assertVertices(graph, "a", "b", "c", "d", "f");
+    assertEdges(graph, ["c", "d"]);
+  });
+
+  it("cascade removes edges", () => {
+    graph.add(["a", "b"], ["a", "c"]).remove("a");
+    assertVertices(graph, "b", "c");
+    assertEdges(graph);
+  });
+});
+
+it("returns new vertices", () => {
+  const vertices = graph.add(["a", "b"]).vertices;
+  vertices.delete("a");
+  assert(graph.has("a"));
+  assert(!vertices.has("a"));
+});
+
+it("returns new edges", () => {
+  const edgesFromA = graph.add(["a", "b"]).edgesFrom("a");
+  edgesFromA.delete("b");
+  assert(graph.edgesFrom("a").has("b"));
+  assert(!edgesFromA.has("b"));
+});
+
+it("throws on absent vertex", () => {
+  assertThrows(() => graph.remove("a"), VertexError, " a");
+  assertThrows(() => graph.remove("z"), VertexError, " z");
+  assertThrows(() => graph.edgesFrom("q"), VertexError, " q");
+  assertThrows(() => graph.edgesFrom("x"), VertexError, " x");
+  assertThrows(() => graph.hasCycle("w"), VertexError, " w");
+  assertThrows(() => graph.subgraph(["a"]), VertexError, " a");
+});
+
+describe("graph.walk", () => {
+  it("traverses depth-first", () => {
+    graph.add(["a", "b", "e"], ["a", "c"], ["a", "d"], ["b", "f"]);
+    const visited: string[] = [];
+    graph.walk("a", (vertex) => void visited.push(vertex));
+    assertEquals(visited, ["b", "e", "f", "c", "d"]);
+  });
+
+  it("can walk in reverse", () => {
+    graph.add(["a", "z"], ["b", "z"], ["c", "z"]);
+    const visited: string[] = [];
+    graph.walk("z", (vertex) => void visited.push(vertex), { reverse: true });
+    assertEquals(visited, ["a", "b", "c"]);
+  });
+
+  it("can return a value", () => {
+    graph.add(["a", "b"], ["a", "c"], ["a", "d"]);
+    const visited: string[] = [];
+    const result = graph
+      .walk("a", (v) => v === "c" ? "stopped at c!" : void visited.push(v));
+    assertEquals(visited, ["b"]);
+    assertEquals(result, "stopped at c!");
+  });
+
+  it("can visit the source", () => {
+    graph.add(["a", "b"], ["a", "c"], ["a", "d"]);
+    const visited: string[] = [];
+    graph.walk(
+      "a",
+      (vertex) => void visited.push(vertex),
+      { includeSource: true },
+    );
+    assertEquals(visited, ["a", "b", "c", "d"]);
+  });
+
+  it("can walk breadth-first", () => {
+    graph.add(["a", "b", "e"], ["a", "c"], ["a", "d"], ["b", "f"]);
+    const visited: string[] = [];
+    graph.walk("a", (v) => void visited.push(v), { breadthFirst: true });
+    assertEquals(visited, ["b", "c", "d", "e", "f"]);
+  });
+
+  it("skips visited vertices", () => {
+    graph.add(["a", "b", "a"]);
+    const visited: string[] = [];
+    graph.walk("a", (v) => void visited.push(v));
+    assertEquals(visited, ["b"]);
+  });
+
+  it("can revisit vertices", () => {
+    graph.add(["a", "b", "a"]);
+    const visited: string[] = [];
+    graph.walk(
+      "a",
+      (v) => visited.push(v) > 8 ? "stop" : undefined,
+      { skipVisited: false },
+    );
+    assertEquals(visited, ["b", "a", "b", "a", "b", "a", "b", "a", "b"]);
+
+    const visited2: string[] = [];
+    graph.walk(
+      "a",
+      (v) => visited2.push(v) > 8 ? "stop" : undefined,
+      { skipVisited: false, breadthFirst: true },
+    );
+    assertEquals(visited2, ["b", "a", "b", "a", "b", "a", "b", "a", "b"]);
+  });
+});
+
+it("finds paths", () => {
+  graph.add(["a", "b", "c", "d"]);
+  assertEquals(graph.paths("a", "b"), [["a", "b"]]);
+  assertEquals(graph.paths("a", "c"), [["a", "b", "c"]]);
+  assertEquals(graph.paths("a", "d"), [["a", "b", "c", "d"]]);
+
+  graph.add(["a", "c"]);
+  assertEquals(graph.paths("a", "b"), [["a", "b"]]);
+  assertEquals(graph.paths("a", "c"), [["a", "b", "c"], ["a", "c"]]);
+  assertEquals(graph.paths("a", "d"), [
+    ["a", "b", "c", "d"],
+    ["a", "c", "d"],
+  ]);
+});
+
+it("detects cycles", () => {
+  graph.add(["a", "b", "c"]);
+  assert(!graph.hasCycle("a"));
+  assert(!graph.hasCycle("b"));
+  assert(!graph.hasCycle("c"));
+
+  graph.add(["c", "a"]);
+  assert(graph.hasCycle("a"));
+  assert(graph.hasCycle("b"));
+  assert(graph.hasCycle("c"));
+});
+
+it("creates subgraphs", () => {
+  graph.add(["a", "b", "c", "d"]);
+  const subgraph = graph.subgraph(["a", "b", "c"]);
+  assertVertices(subgraph, "a", "b", "c");
+  assertEdges(subgraph, ["a", "b"], ["b", "c"]);
+
+  const subgraph2 = graph.subgraph(["a", "b", "c", "d"]);
+  assertVertices(subgraph2, ...graph.vertices);
+  assertEdges(subgraph2, ...graph.edges);
+
+  const subgraph3 = graph.subgraph(["b", "d"]);
+  assertVertices(subgraph3, "b", "d");
+  assertEdges(subgraph3);
+});
+
+describe("integration: collection.smallest", () => {
+  it("gets shortest path", () => {
+    type T = string;
+    const graph = new DirectedGraph<T>();
+    const sm = (a: T, b: T) => smallest(graph.paths(a, b));
+
+    graph.add(["a", "b", "c", "d"]);
+    assertEquals(sm("a", "b"), [["a", "b"]]);
+    assertEquals(sm("a", "c"), [["a", "b", "c"]]);
+    assertEquals(sm("a", "d"), [["a", "b", "c", "d"]]);
 
     graph.add(["a", "c"]);
-    assertEquals(graph.paths("a", "b"), [["a", "b"]]);
-    assertEquals(graph.paths("a", "c"), [["a", "b", "c"], ["a", "c"]]);
-    assertEquals(graph.paths("a", "d"), [
-      ["a", "b", "c", "d"],
-      ["a", "c", "d"],
-    ]);
-  });
+    assertEquals(sm("a", "b"), [["a", "b"]]);
+    assertEquals(sm("a", "c"), [["a", "c"]]);
+    assertEquals(sm("a", "d"), [["a", "c", "d"]]);
 
-  it("identifies if a vertex has cycles", () => {
-    graph.add(["a", "b", "c"]);
-    assert(!graph.hasCycle("a"));
-    assert(!graph.hasCycle("b"));
-    assert(!graph.hasCycle("c"));
-
-    graph.add(["c", "a"]);
-    assert(graph.hasCycle("a"));
-    assert(graph.hasCycle("b"));
-    assert(graph.hasCycle("c"));
-  });
-
-  it("creates subgraphs", () => {
-    graph.add(["a", "b", "c", "d"]);
-    const subgraph = graph.subgraph(["a", "b", "c"]);
-    assertVertices(subgraph, "a", "b", "c");
-    assertEdges(subgraph, ["a", "b"], ["b", "c"]);
-
-    const subgraph2 = graph.subgraph(["a", "b", "c", "d"]);
-    assertVertices(subgraph2, ...graph.vertices);
-    assertEdges(subgraph2, ...graph.edges);
-
-    const subgraph3 = graph.subgraph(["b", "d"]);
-    assertVertices(subgraph3, "b", "d");
-    assertEdges(subgraph3);
-  });
-
-  describe("integration: collection.smallest", () => {
-    it("gets shortest paths between vertices", () => {
-      type T = string;
-      const graph = new DirectedGraph<T>();
-      const sm = (a: T, b: T) => smallest(graph.paths(a, b));
-
-      graph.add(["a", "b", "c", "d"]);
-      assertEquals(sm("a", "b"), [["a", "b"]]);
-      assertEquals(sm("a", "c"), [["a", "b", "c"]]);
-      assertEquals(sm("a", "d"), [["a", "b", "c", "d"]]);
-
-      graph.add(["a", "c"]);
-      assertEquals(sm("a", "b"), [["a", "b"]]);
-      assertEquals(sm("a", "c"), [["a", "c"]]);
-      assertEquals(sm("a", "d"), [["a", "c", "d"]]);
-
-      graph.add(["b", "d"]);
-      assertEquals(sm("a", "b"), [["a", "b"]]);
-      assertEquals(sm("a", "c"), [["a", "c"]]);
-      assertEquals(sm("a", "d"), [["a", "b", "d"], ["a", "c", "d"]]);
-    });
+    graph.add(["b", "d"]);
+    assertEquals(sm("a", "b"), [["a", "b"]]);
+    assertEquals(sm("a", "c"), [["a", "c"]]);
+    assertEquals(sm("a", "d"), [["a", "b", "d"], ["a", "c", "d"]]);
   });
 });

--- a/md/codeBlock/create.test.ts
+++ b/md/codeBlock/create.test.ts
@@ -1,26 +1,20 @@
-import { assert, assertEquals, describe, it } from "../../_deps/testing.ts";
+import { assert, assertEquals, test } from "../../_deps/testing.ts";
 import { create } from "./create.ts";
 
-describe("create", () => {
-  it("defaults to indented code blocks", () =>
-    assertEquals(
-      create("const a = 1;"),
-      "    const a = 1;",
-    ));
+test("defaults", () =>
+  assertEquals(
+    create("const a = 1;"),
+    "    const a = 1;",
+  ));
 
-  describe("options.lang", () => {
-    it("always fences", () =>
-      assert(
-        create("const a: number = 1;", { lang: "ts" })
-          .startsWith("```"),
-      ));
-  });
+test("options.lang adds fences", () =>
+  assert(
+    create("const a: number = 1;", { lang: "ts" })
+      .startsWith("```"),
+  ));
 
-  describe("options.meta", () => {
-    it("always fences", () =>
-      assertEquals(
-        create("const a: number = 1;", { meta: "some info" }),
-        "```nocode some info\nconst a: number = 1;\n```",
-      ));
-  });
-});
+test("options.meta adds fences", () =>
+  assertEquals(
+    create("const a: number = 1;", { meta: "some info" }),
+    "```nocode some info\nconst a: number = 1;\n```",
+  ));

--- a/md/codeBlock/fenced.test.ts
+++ b/md/codeBlock/fenced.test.ts
@@ -1,103 +1,83 @@
-import { assert, assertEquals, describe, it } from "../../_deps/testing.ts";
+import { assert, assertEquals, describe, test } from "../../_deps/testing.ts";
 import { create, findAll, parse } from "./fenced.ts";
 
 describe("create", () => {
-  it("defaults to ```", () => assertEquals(create("!"), "```\n!\n```"));
+  test("default", () => assertEquals(create("!"), "```\n!\n```"));
 
-  describe("options.char", () => {
-    it("defaults to `", () =>
-      assertEquals(
-        create("const a = 1;", { char: "`" }),
-        "```\nconst a = 1;\n```",
-      ));
+  test("options.char", () => {
+    assertEquals(
+      create("const a = 1;", { char: "`" }),
+      "```\nconst a = 1;\n```",
+    );
 
-    it("can use ~", () =>
-      assertEquals(
-        create("````", { char: "~" }),
-        "~~~\n````\n~~~",
-      ));
+    assertEquals(
+      create("````", { char: "~" }),
+      "~~~\n````\n~~~",
+    );
 
-    it("always uses ~ if info has `", () =>
-      assertEquals(
-        create("", { char: "`", lang: "`" }),
-        "~~~`\n\n~~~",
-      ));
+    assertEquals(
+      create("", { char: "`", lang: "`" }),
+      "~~~`\n\n~~~",
+    );
   });
 
-  describe("fence", () => {
-    it("adds ` as needed", () =>
-      assertEquals(
-        create("````", { char: "`" }),
-        "`````\n````\n`````",
-      ));
+  test("created fence", () => {
+    assertEquals(
+      create("````", { char: "`" }),
+      "`````\n````\n`````",
+    );
 
-    it("adds ~ as needed", () =>
-      assertEquals(
-        create("~~~", { char: "~" }),
-        "~~~~\n~~~\n~~~~",
-      ));
+    assertEquals(
+      create("~~~", { char: "~" }),
+      "~~~~\n~~~\n~~~~",
+    );
   });
 
-  describe("lang", () => {
-    it("appears on the first line", () =>
-      assert(
-        create("", { lang: "ts" })
-          .split("\n")[0]
-          .endsWith("ts"),
-      ));
-  });
+  test("options.lang", () =>
+    assert(
+      create("", { lang: "ts" })
+        .split("\n")[0]
+        .endsWith("ts"),
+    ));
 
-  describe("meta", () => {
-    it("appears in the first line", () =>
-      assert(
-        create("", { meta: "some info" })
-          .split("\n")[0]
-          .endsWith("some info"),
-      ));
-  });
+  test("options.meta", () =>
+    assert(
+      create("", { meta: "some info" })
+        .split("\n")[0]
+        .endsWith("some info"),
+    ));
 });
 
 describe("parse", () => {
-  it('has result.type "fenced"', () =>
-    assertEquals(parse("```\n```").type, "fenced"));
+  test("result.type", () => assertEquals(parse("```\n```").type, "fenced"));
 
-  describe("result.char", () => {
-    it('can be "`"', () => assertEquals(parse("```\n```").char, "`"));
-    it('can be "~"', () => assertEquals(parse("~~~\n~~~").char, "~"));
+  test("result.char", () => {
+    assertEquals(parse("```\n```").char, "`");
+    assertEquals(parse("~~~\n~~~").char, "~");
   });
 
-  describe("result.fence", () => {
-    it('can be "`"', () => assertEquals(parse("```\n```").fence, "```"));
-    it('can be "~"', () => assertEquals(parse("~~~\n~~~").fence, "~~~"));
+  test("result.fence", () => {
+    assertEquals(parse("```\n```").fence, "```");
+    assertEquals(parse("~~~\n~~~").fence, "~~~");
   });
 
-  describe("result.code", () => {
-    it('defaults to ""', () => assertEquals(parse("```\n```").code, ""));
-
-    it("gets code from one-line blocks", () =>
-      assertEquals(parse("```\nfoo\n```").code, "foo"));
-
-    it("gets code from multi-line blocks", () =>
-      assertEquals(parse("```\nfoo\n bar\n```").code, "foo\n bar"));
+  test("result.code", () => {
+    assertEquals(parse("```\n```").code, "");
+    assertEquals(parse("```\nfoo\n```").code, "foo");
+    assertEquals(parse("```\nfoo\n bar\n```").code, "foo\n bar");
   });
 
-  describe("result.lang", () => {
-    it("defaults to undefined", () =>
-      assertEquals(parse("```\n```").lang, undefined));
-
-    it("gets first word of info string", () =>
-      assertEquals(parse("```lang meta data\n```").lang, "lang"));
+  test("result.lang", () => {
+    assertEquals(parse("```\n```").lang, undefined);
+    assertEquals(parse("```lang meta data\n```").lang, "lang");
   });
 
-  describe("result.meta", () => {
-    it("defaults to undefined", () =>
-      assertEquals(parse("```\n```").meta, undefined));
-
-    it("gets rest of info string", () =>
-      assertEquals(parse("```lang meta data\n```").meta, "meta data"));
+  test("result.meta", () => {
+    assertEquals(parse("```\n```").meta, undefined);
+    assertEquals(parse("```lang meta data\n```").meta, "meta data");
   });
 
-  it("handles Windows newlines", () =>
+  test("w/ Windows newlines", () =>
     assertEquals(
       parse("```\r\nHello!\r\n```"),
       {
@@ -109,16 +89,15 @@ describe("parse", () => {
     ));
 });
 
-describe("findAll", () => {
-  it("returns blocks with locations", () =>
-    assertEquals(
-      findAll(
-        "foo\n\n    bar\n\n```baz\nqux\n```" +
-          "   quux\n\n```corge\ngrault\n```",
-      ),
-      [
-        ["```baz\nqux\n```", { column: 1, line: 5, offset: 14 }],
-        ["```corge\ngrault\n```", { column: 1, line: 9, offset: 37 }],
-      ],
-    ));
+test("findAll", () => {
+  assertEquals(
+    findAll(
+      "foo\n\n    bar\n\n```baz\nqux\n```" +
+        "   quux\n\n```corge\ngrault\n```",
+    ),
+    [
+      ["```baz\nqux\n```", { column: 1, line: 5, offset: 14 }],
+      ["```corge\ngrault\n```", { column: 1, line: 9, offset: 37 }],
+    ],
+  );
 });

--- a/md/codeBlock/findAll.test.ts
+++ b/md/codeBlock/findAll.test.ts
@@ -1,13 +1,11 @@
-import { assertEquals, describe, it } from "../../_deps/testing.ts";
+import { assertEquals, it } from "../../_deps/testing.ts";
 import { findAll } from "./findAll.ts";
 
-describe("findAll", () => {
-  it("returns blocks with locations", () =>
-    assertEquals(
-      findAll("foo\n\n    bar\n\n```baz\nqux\n```"),
-      [
-        ["    bar", { column: 1, line: 3, offset: 5 }],
-        ["```baz\nqux\n```", { column: 1, line: 5, offset: 14 }],
-      ],
-    ));
-});
+it("gets blocks & locations", () =>
+  assertEquals(
+    findAll("foo\n\n    bar\n\n```baz\nqux\n```"),
+    [
+      ["    bar", { column: 1, line: 3, offset: 5 }],
+      ["```baz\nqux\n```", { column: 1, line: 5, offset: 14 }],
+    ],
+  ));

--- a/md/codeBlock/indented.test.ts
+++ b/md/codeBlock/indented.test.ts
@@ -2,71 +2,43 @@ import {
   assertEquals,
   assertThrows,
   describe,
-  it,
+  test,
 } from "../../_deps/testing.ts";
 import { create, findAll, parse } from "./indented.ts";
 
-describe("create", () => {
-  it("handles single-line code", () => assertEquals(create("foo"), "    foo"));
+function assertParse(code: string, expected: string): void {
+  assertEquals(parse(code).code, expected);
+}
 
-  it("handles multi-line code", () =>
-    assertEquals(create("foo\n  bar\nbaz"), "    foo\n      bar\n    baz"));
+test("create", () => {
+  assertEquals(create("foo"), "    foo");
+  assertEquals(create("foo\n  bar\nbaz"), "    foo\n      bar\n    baz");
 });
 
 describe("parse", () => {
-  it("throws if input is invalid", () => void assertThrows(() => parse("")));
-
-  it('has result.type "indented"', () =>
-    assertEquals(parse("    ").type, "indented"));
+  test("invalid input", () => void assertThrows(() => parse("")));
+  test(".type", () => assertEquals(parse("    X").type, "indented"));
 
   describe("result.code", () => {
-    it('defaults to ""', () => assertEquals(parse("    ").code, ""));
-
-    it("gets code from one-line blocks", () =>
-      assertEquals(parse("    foo").code, "foo"));
-
-    it("handles increased indentation", () =>
-      assertEquals(parse("      foo").code, "foo"));
-
-    it("gets code from multi-line blocks", () =>
-      assertEquals(parse("    foo\n    bar").code, "foo\nbar"));
-
-    it("handles mixed indentation", () =>
-      assertEquals(parse("     foo\n    bar").code, " foo\nbar"));
-
-    it("trims trailing whitespace", () =>
-      assertEquals(
-        parse("    foo \n    bar\n\n\n").code,
-        "foo\nbar",
-      ));
-
-    it("trims leading blank lines", () =>
-      assertEquals(
-        parse("\n\n\n    foo\n    bar").code,
-        "foo\nbar",
-      ));
-
-    it("includes intermediate blank lines", () =>
-      assertEquals(
-        parse("    foo\n\n\n    bar").code,
-        "foo\n\n\nbar",
-      ));
+    test("single lines", () => assertParse("    foo", "foo"));
+    test("extra indents", () => assertParse("      foo", "foo"));
+    test("multiple lines", () => assertParse("    foo\n    bar", "foo\nbar"));
+    test("mixed indents", () => assertParse("     foo\n    bar", " foo\nbar"));
+    test("blank lines", () => assertParse("    X\n\n\n    Y", "X\n\n\nY"));
   });
 
-  it("has result.indentation", () =>
+  test("result.indentation", () =>
     assertEquals(parse("      foo").indentation, "      "));
 });
 
-describe("findAll", () => {
-  it("returns blocks with locations", () =>
-    assertEquals(
-      findAll(
-        "ex\n    foo\n\n    bar\n\n```baz\nqux\n```\n" +
-          "      quux\n\n```corge\ngrault\n```",
-      ),
-      [
-        ["    foo\n\n    bar", { column: 1, line: 2, offset: 3 }],
-        ["      quux", { column: 1, line: 9, offset: 36 }],
-      ],
-    ));
-});
+test("findAll", () =>
+  assertEquals(
+    findAll(
+      "ex\n    foo\n\n    bar\n\n```baz\nqux\n```\n" +
+        "      quux\n\n```corge\ngrault\n```",
+    ),
+    [
+      ["    foo\n\n    bar", { column: 1, line: 2, offset: 3 }],
+      ["      quux", { column: 1, line: 9, offset: 36 }],
+    ],
+  ));

--- a/md/codeBlock/infoString.test.ts
+++ b/md/codeBlock/infoString.test.ts
@@ -3,6 +3,7 @@ import {
   assertThrows,
   describe,
   it,
+  test,
 } from "../../_deps/testing.ts";
 import {
   InfoStringError,
@@ -14,22 +15,20 @@ import {
 describe("stringify", () => {
   it('defaults to ""', () => assertEquals(stringify(), ""));
 
-  it("starts with lang; ends with meta", () =>
+  it("has lang then meta", () =>
     assertEquals(stringify({ lang: "ts", meta: "foo" }), "ts foo"));
 
-  describe("lang", () => {
-    it("throws custom error on whitespace", () =>
-      void assertThrows(() => stringify({ lang: "t s\n" }), LanguageError));
-  });
+  test("lang w/ whitespace", () =>
+    void assertThrows(() => stringify({ lang: "t s\n" }), LanguageError));
 
   describe("meta", () => {
-    it("throws custom error on newlines", () =>
+    it("throws on newlines", () =>
       void assertThrows(() => stringify({ meta: "\n" }), InfoStringError));
 
     it("has fallback lang", () =>
       assertEquals(stringify({ meta: "foo" }), "nocode foo"));
 
-    it("can ignore fallback lang", () =>
+    it("can ignore lang", () =>
       assertEquals(stringify({ meta: "foo", lang: "" }), "foo"));
 
     it("trims the value", () =>
@@ -40,9 +39,9 @@ describe("stringify", () => {
 describe("parse", () => {
   it("defaults to {}", () => assertEquals(parse(""), {}));
 
-  it("treats first word as lang", () =>
+  it("reads first word as lang", () =>
     assertEquals(parse("foo bar baz qux").lang, "foo"));
 
-  it("treats the rest as meta", () =>
+  it("reads the rest as meta", () =>
     assertEquals(parse("foo bar baz qux").meta, "bar baz qux"));
 });

--- a/md/codeBlock/parse.test.ts
+++ b/md/codeBlock/parse.test.ts
@@ -1,27 +1,25 @@
-import { assertEquals, describe, it } from "../../_deps/testing.ts";
+import { assertEquals, test } from "../../_deps/testing.ts";
 import { parse } from "./parse.ts";
 
-describe("parse", () => {
-  it("parses indented code blocks", () =>
-    assertEquals(
-      parse("    foo\n    bar"),
-      {
-        type: "indented",
-        indentation: "    ",
-        code: "foo\nbar",
-      },
-    ));
+test("parses indented blocks", () =>
+  assertEquals(
+    parse("    foo\n    bar"),
+    {
+      type: "indented",
+      indentation: "    ",
+      code: "foo\nbar",
+    },
+  ));
 
-  it("parses fenced code blocks", () =>
-    assertEquals(
-      parse("```lang meta data\nfoo\nbar\n```"),
-      {
-        type: "fenced",
-        char: "`",
-        fence: "```",
-        lang: "lang",
-        meta: "meta data",
-        code: "foo\nbar",
-      },
-    ));
-});
+test("parses fenced blocks", () =>
+  assertEquals(
+    parse("```lang meta data\nfoo\nbar\n```"),
+    {
+      type: "fenced",
+      char: "`",
+      fence: "```",
+      lang: "lang",
+      meta: "meta data",
+      code: "foo\nbar",
+    },
+  ));

--- a/mermaid/flowchart.test.ts
+++ b/mermaid/flowchart.test.ts
@@ -1,39 +1,37 @@
 import { assertEquals, describe, it } from "../_deps/testing.ts";
 import { flowchart } from "./flowchart.ts";
 
-describe("flowchart", () => {
-  it("accepts an array of edges", () =>
+it("accepts edges", () => {
+  assertEquals(
+    flowchart([["a", "b"]]),
+    "```mermaid\nflowchart LR\n    a --> b\n```",
+  );
+
+  assertEquals(
+    flowchart(new Set([["c", "d"]])),
+    "```mermaid\nflowchart LR\n    c --> d\n```",
+  );
+});
+
+describe("direction option", () => {
+  it("defaults to LR", () =>
     assertEquals(
-      flowchart([["a", "b"]]),
-      "```mermaid\nflowchart LR\n    a --> b\n```",
+      flowchart([]),
+      "```mermaid\nflowchart LR\n\n```",
     ));
 
-  it("accepts a set of edges", () =>
+  it("is configurable", () =>
     assertEquals(
-      flowchart(new Set([["c", "d"]])),
-      "```mermaid\nflowchart LR\n    c --> d\n```",
+      flowchart([], { direction: "TD" }),
+      "```mermaid\nflowchart TD\n\n```",
     ));
+});
 
-  describe("direction option", () => {
-    it("defaults to LR", () =>
-      assertEquals(
-        flowchart([]),
-        "```mermaid\nflowchart LR\n\n```",
-      ));
-
-    it("is configurable", () =>
-      assertEquals(
-        flowchart([], { direction: "TD" }),
-        "```mermaid\nflowchart TD\n\n```",
-      ));
-  });
-
-  describe("other options", () => {
-    it("can render a title", () => {
-      assertEquals(
-        flowchart([], { title: "Hello World" }),
-        "```mermaid\n---\ntitle: Hello World\n---\nflowchart LR\n\n```",
-      );
-    });
+describe("other options", () => {
+  it("can render a title", () => {
+    assertEquals(
+      flowchart([], { title: "Hello World" }),
+      "```mermaid\n---\ntitle: Hello World\n---\nflowchart LR\n\n```",
+    );
   });
 });

--- a/object/setNestedEntry.test.ts
+++ b/object/setNestedEntry.test.ts
@@ -1,23 +1,21 @@
-import { assertEquals, describe, it } from "../_deps/testing.ts";
+import { assertEquals, it } from "../_deps/testing.ts";
 import { setNestedEntry } from "./setNestedEntry.ts";
 
 const s = Symbol("");
 const val = () => {};
 
-describe("object.setNestedEntry", () => {
-  it("creates intermediate objects", () =>
-    assertEquals(
-      setNestedEntry({}, ["a", 2, s], val),
-      { a: { 2: { [s]: val } } },
-    ));
+it("creates medial objects", () =>
+  assertEquals(
+    setNestedEntry({}, ["a", 2, s], val),
+    { a: { 2: { [s]: val } } },
+  ));
 
-  it("overwrites existing values", () =>
-    assertEquals(
-      setNestedEntry(
-        { a: { b: 7 } },
-        ["a", "b"],
-        5,
-      ),
-      { a: { b: 5 } },
-    ));
-});
+it("overwrites", () =>
+  assertEquals(
+    setNestedEntry(
+      { a: { b: 7 } },
+      ["a", "b"],
+      5,
+    ),
+    { a: { b: 5 } },
+  ));

--- a/path/dir.test.ts
+++ b/path/dir.test.ts
@@ -1,29 +1,26 @@
-import { assertEquals, describe, it } from "../_deps/testing.ts";
+import { assertEquals, describe, test } from "../_deps/testing.ts";
 import { dir } from "./dir.ts";
+
+function assertDir(input: string | URL | ImportMeta, expected: string): void {
+  assertEquals(dir(input), expected);
+}
 
 describe("w/ string input", () => {
   describe("w/ Posix separators", () => {
-    it("works on filepaths", () => assertEquals(dir("/foo/*.ts"), "/foo"));
-
-    it("works on dirpaths", () => assertEquals(dir("/foo/bar/"), "/foo"));
+    test("filepaths", () => assertDir("/foo/*.ts", "/foo"));
+    test("dirpaths", () => assertDir("/foo/bar/", "/foo"));
   });
 
   describe("w/ Windows separators", () => {
-    it("works on filepaths", () => assertEquals(dir("\\foo\\*.ts"), "\\foo"));
-
-    it("works on dirpaths", () => assertEquals(dir("\\foo\\bar\\"), "\\foo"));
+    test("filepaths", () => assertDir("\\foo\\*.ts", "\\foo"));
+    test("dirpaths", () => assertDir("\\foo\\bar\\", "\\foo"));
   });
 });
 
 describe("w/ URL input", () => {
-  it("works on filepaths", () =>
-    assertEquals(dir(new URL("file:///foo/*.ts")), "/foo"));
-
-  it("works on dirpaths", () =>
-    assertEquals(dir(new URL("file:///foo/bar/")), "/foo"));
-
-  it("works on webpaths", () =>
-    assertEquals(dir(new URL("https://deno.land/x/")), "/"));
+  test("filepaths", () => assertDir(new URL("file:///foo/*.ts"), "/foo"));
+  test("dirpaths", () => assertDir(new URL("file:///foo/bar/"), "/foo"));
+  test("webpaths", () => assertDir(new URL("https://deno.land/x/"), "/"));
 });
 
 describe("w/ ImportMeta input", () => {
@@ -32,5 +29,5 @@ describe("w/ ImportMeta input", () => {
     __dirname = __dirname.slice(1).replace(/\//g, "\\");
   }
 
-  it("works on this file", () => assertEquals(dir(import.meta), __dirname));
+  test("this file", () => assertDir(import.meta, __dirname));
 });

--- a/path/globRoot.test.ts
+++ b/path/globRoot.test.ts
@@ -1,24 +1,18 @@
-import { assertEquals, describe, it } from "../_deps/testing.ts";
+import { assertEquals, describe, test } from "../_deps/testing.ts";
 import { globRoot } from "./globRoot.ts";
 
+function assertGlobRoot(input: string, expected: string): void {
+  assertEquals(globRoot(input), expected);
+}
+
 describe("w/ Unix separators", () => {
-  it("finds root of an absolute glob pattern", () =>
-    assertEquals(globRoot("/foo/bar/*.ts"), "/foo/bar/"));
-
-  it("finds root of a relative glob pattern", () =>
-    assertEquals(globRoot("foo/bar/*.ts"), "foo/bar/"));
-
-  it("returns a non-glob path as-is", () =>
-    assertEquals(globRoot("/foo/bar/"), "/foo/bar/"));
+  test("absolute globs", () => assertGlobRoot("/foo/bar/*.ts", "/foo/bar/"));
+  test("relative globs", () => assertGlobRoot("foo/bar/*.ts", "foo/bar/"));
+  test("non-globs", () => assertGlobRoot("/foo/bar/", "/foo/bar/"));
 });
 
 describe("w/ Windows separators", () => {
-  it("finds root of an absolute glob pattern", () =>
-    assertEquals(globRoot("C:\\\\foo\\bar\\*.ts"), "C:\\\\foo\\bar\\"));
-
-  it("finds root of a relative glob pattern", () =>
-    assertEquals(globRoot("foo\\bar\\*.ts"), "foo\\bar\\"));
-
-  it("returns a non-glob path as-is", () =>
-    assertEquals(globRoot("C:\\\\foo\\bar\\"), "C:\\\\foo\\bar\\"));
+  test("absolute globs", () => assertGlobRoot("C:\\\\X\\*.ts", "C:\\\\X\\"));
+  test("relative globs", () => assertGlobRoot("foo\\bar\\*.ts", "foo\\bar\\"));
+  test("non-globs", () => assertGlobRoot("C:\\\\foo\\", "C:\\\\foo\\"));
 });

--- a/string/Text.test.ts
+++ b/string/Text.test.ts
@@ -1,33 +1,28 @@
-import { assertEquals, assertThrows, describe, it } from "../_deps/testing.ts";
+import {
+  assertEquals,
+  assertThrows,
+  describe,
+  test,
+} from "../_deps/testing.ts";
 import { Text } from "./Text.ts";
 
-describe("input", () => {
-  it("is the input string", () => {
-    assertEquals(new Text("a").input, "a");
-  });
+describe(".input is the input", () => assertEquals(new Text("a").input, "a"));
+
+describe(".value is .input", () => {
+  const text = new Text("a");
+  assertEquals(text.value, text.input);
 });
 
-describe("value", () => {
-  it("equals .input", () => {
-    const text = new Text("a");
-    assertEquals(text.value, text.input);
-  });
-});
-
-describe("length", () => {
-  it("measures .input", () => {
-    assertEquals(new Text("a").length, 1);
-    assertEquals(new Text("ab").length, 2);
-    assertEquals(new Text("").length, 0);
-  });
+describe(".length measures .input", () => {
+  assertEquals(new Text("a").length, 1);
+  assertEquals(new Text("ab").length, 2);
+  assertEquals(new Text("").length, 0);
 });
 
 describe("lines", () => {
-  it('handles ""', () => {
-    assertEquals(new Text("").lines, [""]);
-  });
+  test('""', () => assertEquals(new Text("").lines, [""]));
 
-  it("handles newlines", () => {
+  test("newlines", () => {
     assertEquals(new Text("ab\nc").lines, ["ab\n", "c"]);
     assertEquals(new Text("ab\rc").lines, ["ab\r", "c"]);
     assertEquals(new Text("ab\r\nc").lines, ["ab\r\n", "c"]);
@@ -36,65 +31,52 @@ describe("lines", () => {
     assertEquals(new Text("ab\r\n\r\nc").lines, ["ab\r\n", "\r\n", "c"]);
   });
 
-  it("handles the examples", () => {
-    assertEquals(new Text("a\n\nb").lines, ["a\n", "\n", "b"]);
-  });
+  test("the examples", () =>
+    assertEquals(new Text("a\n\nb").lines, ["a\n", "\n", "b"]));
 });
 
 describe("positionAt()", () => {
-  describe("invalid values", () => {
+  describe("invalid values throw", () => {
     const text = new Text("a");
 
-    it("throws if too large", () =>
-      void assertThrows(() => text.positionAt(2)));
-
-    it("throws if too small", () =>
-      void assertThrows(() => text.positionAt(-2)));
-
-    it("throws if NaN", () => void assertThrows(() => text.positionAt(NaN)));
-
-    it("throws if float", () => void assertThrows(() => text.positionAt(0.1)));
+    assertThrows(() => text.positionAt(2));
+    assertThrows(() => text.positionAt(-2));
+    assertThrows(() => text.positionAt(NaN));
+    assertThrows(() => text.positionAt(0.1));
   });
 
   describe("valid values", () => {
-    it('handles ""', () => {
+    test('""', () => {
       assertEquals(new Text("").positionAt(0), 0);
       assertEquals(new Text("").positionAt(-0), 0);
     });
 
-    it("can locate end of text", () => {
-      assertEquals(new Text("a\nb").positionAt(-0), 3);
-    });
+    test("-0 is text end", () =>
+      assertEquals(new Text("a\nb").positionAt(-0), 3));
 
-    it("handles newlines", () => {
+    test("newlines", () => {
       assertEquals(new Text("a\nb").positionAt(2), 2);
       assertEquals(new Text("a\rb").positionAt(2), 2);
       assertEquals(new Text("a\r\nb").positionAt(3), 3);
     });
 
-    it("handles the examples", () => {
-      assertEquals(new Text("a\n\nb").positionAt(3), 3);
-    });
+    test("the examples", () =>
+      assertEquals(new Text("a\n\nb").positionAt(3), 3));
   });
 });
 
 describe("locationAt()", () => {
-  describe("invalid values", () => {
+  describe("invalid values throw", () => {
     const text = new Text("a");
 
-    it("throws if too large", () =>
-      void assertThrows(() => text.locationAt(2)));
-
-    it("throws if too small", () =>
-      void assertThrows(() => text.locationAt(-2)));
-
-    it("throws if NaN", () => void assertThrows(() => text.locationAt(NaN)));
-
-    it("throws if float", () => void assertThrows(() => text.locationAt(0.1)));
+    test("value too large", () => void assertThrows(() => text.locationAt(2)));
+    test("value too small", () => void assertThrows(() => text.locationAt(-2)));
+    test("value is NaN", () => void assertThrows(() => text.locationAt(NaN)));
+    test("value is float", () => void assertThrows(() => text.locationAt(0.1)));
   });
 
   describe("valid values", () => {
-    it('handles ""', () => {
+    test('""', () => {
       assertEquals(
         new Text("").locationAt(0),
         { offset: 0, line: 1, column: 1 },
@@ -105,14 +87,14 @@ describe("locationAt()", () => {
       );
     });
 
-    it("can locate end of text", () => {
+    test("-0 is text end", () => {
       assertEquals(
         new Text("a\nb").locationAt(-0),
         { offset: 3, line: 2, column: 2 },
       );
     });
 
-    it("handles newlines", () => {
+    test("newlines", () => {
       assertEquals(
         new Text("a\nb").locationAt(2),
         { offset: 2, line: 2, column: 1 },
@@ -127,7 +109,7 @@ describe("locationAt()", () => {
       );
     });
 
-    it("handles the examples", () => {
+    test("the examples", () => {
       assertEquals(
         new Text("a\n\nb").locationAt(3),
         { offset: 3, line: 3, column: 1 },

--- a/string/TextCursor.test.ts
+++ b/string/TextCursor.test.ts
@@ -1,5 +1,5 @@
 import { stripColor } from "../_deps/fmt.ts";
-import { assert, assertEquals, describe, it } from "../_deps/testing.ts";
+import { assert, assertEquals, describe, it, test } from "../_deps/testing.ts";
 import { TextCursor } from "./TextCursor.ts";
 import { dedent } from "./dedent.ts";
 
@@ -8,117 +8,88 @@ const longStr =
   "the quick brown fox jumps over the lazy dog then does it again and again until it is tired";
 const maxLength = 39;
 
-describe("new TextCursor()", () => {
-  it("requires a string", () => assert(new TextCursor(str)));
+test("new TextCursor()", () => {
+  const cursorA = new TextCursor(str);
+  const cursorB = new TextCursor(cursorA);
 
-  it("can clone a cursor", () => {
-    const cursorA = new TextCursor(str);
-    const cursorB = new TextCursor(cursorA);
-    assert(cursorA !== cursorB);
-    assertEquals(cursorA.index, cursorB.index);
-    assertEquals(cursorA.input, cursorB.input);
-  });
+  assert(cursorA !== cursorB);
 
-  it("can clone w/ new index", () => {
-    const cursorA = new TextCursor(str);
-    const cursorB = new TextCursor(cursorA, 3);
-    assert(cursorA !== cursorB);
-    assertEquals(cursorA.input, cursorB.input);
-    assertEquals(cursorB.index, 3);
-  });
+  assertEquals(cursorA.index, cursorB.index);
+  assertEquals(cursorA.input, cursorB.input);
+
+  const cursorC = new TextCursor(cursorA, 3);
+  assertEquals(cursorC.index, 3);
 });
 
-describe("TextCursor.index", () => {
-  it("starts at 0", () => assertEquals(new TextCursor(str).index, 0));
-
-  it("can be initialized", () => assertEquals(new TextCursor(str, 3).index, 3));
+test(".index", () => {
+  assertEquals(new TextCursor(str).index, 0);
+  assertEquals(new TextCursor(str, 3).index, 3);
 });
 
-describe("TextCursor.move()", () => {
-  it("moves the index", () => {
-    assertEquals(new TextCursor(str).move(3).index, 3);
-    assertEquals(new TextCursor(str, 3).move(2).index, 5);
-  });
+test(".move()", () => {
+  assertEquals(new TextCursor(str).move(3).index, 3);
+  assertEquals(new TextCursor(str, 3).move(2).index, 5);
 
-  it("returns a new cursor", () => {
-    const cursor = new TextCursor(str);
-    assert(cursor !== cursor.move(3));
-  });
+  const cursor = new TextCursor(str);
+  assert(cursor !== cursor.move(3));
 });
 
-describe("TextCursor.char", () => {
-  it("is the index character", () =>
-    assertEquals(new TextCursor(str, 2).char, "a"));
+test(".char", () => assertEquals(new TextCursor(str, 2).char, "a"));
+
+test(".remainder", () => {
+  assertEquals(new TextCursor(str).remainder, str);
+  assertEquals(new TextCursor(str, 3).remainder, "t: example");
 });
 
-describe("TextCursor.remainder", () => {
-  it("defaults to full input", () =>
-    assertEquals(new TextCursor(str).remainder, str));
-
-  it("is index onward", () =>
-    assertEquals(new TextCursor(str, 3).remainder, "t: example"));
+test(".antecedent", () => {
+  assertEquals(new TextCursor(str).antecedent, "");
+  assertEquals(new TextCursor(str, 3).antecedent, "fea");
 });
 
-describe("TextCursor.antecedent", () => {
-  it("is empty by default", () =>
-    assertEquals(new TextCursor(str).antecedent, ""));
+test(".location", () => {
+  const text = "a\n\nbc\nd\nef";
+  const cursor = new TextCursor(text);
 
-  it("is value before index", () =>
-    assertEquals(new TextCursor(str, 3).antecedent, "fea"));
+  assertEquals(cursor.location, { offset: 0, line: 1, column: 1 });
+  assertEquals(cursor.move(1).location, { offset: 1, line: 1, column: 2 });
+  assertEquals(cursor.move(2).location, { offset: 2, line: 2, column: 1 });
+  assertEquals(cursor.move(3).location, { offset: 3, line: 3, column: 1 });
+  assertEquals(cursor.move(4).location, { offset: 4, line: 3, column: 2 });
+  assertEquals(cursor.move(5).location, { offset: 5, line: 3, column: 3 });
+  assertEquals(cursor.move(6).location, { offset: 6, line: 4, column: 1 });
+  assertEquals(cursor.move(7).location, { offset: 7, line: 4, column: 2 });
+  assertEquals(cursor.move(8).location, { offset: 8, line: 5, column: 1 });
+  assertEquals(cursor.move(9).location, { offset: 9, line: 5, column: 2 });
 });
 
-describe("TextCursor.location", () => {
-  it("is index Text.Location", () => {
-    const text = "a\n\nbc\nd\nef";
-    const cursor = new TextCursor(text);
+test(".line", () => {
+  const text = "a\n\nbc\nd\nef";
 
-    assertEquals(cursor.location, { offset: 0, line: 1, column: 1 });
-    assertEquals(cursor.move(1).location, { offset: 1, line: 1, column: 2 });
-    assertEquals(cursor.move(2).location, { offset: 2, line: 2, column: 1 });
-    assertEquals(cursor.move(3).location, { offset: 3, line: 3, column: 1 });
-    assertEquals(cursor.move(4).location, { offset: 4, line: 3, column: 2 });
-    assertEquals(cursor.move(5).location, { offset: 5, line: 3, column: 3 });
-    assertEquals(cursor.move(6).location, { offset: 6, line: 4, column: 1 });
-    assertEquals(cursor.move(7).location, { offset: 7, line: 4, column: 2 });
-    assertEquals(cursor.move(8).location, { offset: 8, line: 5, column: 1 });
-    assertEquals(cursor.move(9).location, { offset: 9, line: 5, column: 2 });
-  });
+  assertEquals(new TextCursor(text).line, "a\n");
+  assertEquals(new TextCursor(text, 1).line, "a\n");
+  assertEquals(new TextCursor(text, 2).line, "\n");
+  assertEquals(new TextCursor(text, 3).line, "bc\n");
+  assertEquals(new TextCursor(text, 4).line, "bc\n");
+  assertEquals(new TextCursor(text, 5).line, "bc\n");
+  assertEquals(new TextCursor(text, 6).line, "d\n");
+  assertEquals(new TextCursor(text, 7).line, "d\n");
+  assertEquals(new TextCursor(text, 8).line, "ef");
+  assertEquals(new TextCursor(text, 9).line, "ef");
 });
 
-describe("TextCursor.line", () => {
-  it("is the line at the index", () => {
-    const text = "a\n\nbc\nd\nef";
+describe(".toString() elides input", () =>
+  assertEquals(
+    new TextCursor("abcdefghijklmnopqrstuvwxyz", 13).toString(),
+    'TextCursor("…efghijklmnopqrstuv…", 13)',
+  ));
 
-    assertEquals(new TextCursor(text).line, "a\n");
-    assertEquals(new TextCursor(text, 1).line, "a\n");
-    assertEquals(new TextCursor(text, 2).line, "\n");
-    assertEquals(new TextCursor(text, 3).line, "bc\n");
-    assertEquals(new TextCursor(text, 4).line, "bc\n");
-    assertEquals(new TextCursor(text, 5).line, "bc\n");
-    assertEquals(new TextCursor(text, 6).line, "d\n");
-    assertEquals(new TextCursor(text, 7).line, "d\n");
-    assertEquals(new TextCursor(text, 8).line, "ef");
-    assertEquals(new TextCursor(text, 9).line, "ef");
-  });
+test(".startsWith()", () => {
+  assert(new TextCursor(str).startsWith("feat"));
+  assert(!new TextCursor(str).startsWith("wxyz"));
+  assert(new TextCursor(str, 4).startsWith(": ex"));
 });
 
-describe("TextCursor.toString()", () => {
-  it("is elided around index", () =>
-    assertEquals(
-      new TextCursor("abcdefghijklmnopqrstuvwxyz", 13).toString(),
-      'TextCursor("…efghijklmnopqrstuv…", 13)',
-    ));
-});
-
-describe("TextCursor.startsWith()", () => {
-  it("matches from the index", () => {
-    assert(new TextCursor(str).startsWith("feat"));
-    assert(!new TextCursor(str).startsWith("wxyz"));
-    assert(new TextCursor(str, 4).startsWith(": ex"));
-  });
-});
-
-describe("inspect", () => {
+describe("inspect()", () => {
   it("depicts the location", () =>
     assertEquals(
       stripColor(new TextCursor(str, 3).inspect()),
@@ -128,7 +99,7 @@ describe("inspect", () => {
       `).trim(),
     ));
 
-  it("elides long lines", () =>
+  test("elision", () =>
     assertEquals(
       stripColor(new TextCursor(longStr, 37).inspect({ maxLength })),
       dedent(`
@@ -137,87 +108,70 @@ describe("inspect", () => {
       `).trim(),
     ));
 
-  describe("line numbers", () => {
-    it("shows when >1 lines", () => {
-      const cursor = new TextCursor("a\nb", 1);
+  test("line numbers", () => {
+    const cursor = new TextCursor("a\nb", 1);
 
-      assertEquals(
-        stripColor(cursor.inspect()),
-        dedent(`
+    assertEquals(
+      stripColor(cursor.inspect()),
+      dedent(`
           [L1] a¶
                 ^
         `).trim(),
-      );
+    );
 
-      assertEquals(
-        stripColor(new TextCursor("a\nb", 2).inspect()),
-        dedent(`
+    assertEquals(
+      stripColor(new TextCursor("a\nb", 2).inspect()),
+      dedent(`
           [L2] b
                ^
         `).trim(),
-      );
-    });
+    );
 
-    it("is configurable", () => {
-      const cursor = new TextCursor("a\nb", 1);
-
-      assertEquals(
-        stripColor(cursor.inspect({ lineNumber: false })),
-        dedent(`
+    assertEquals(
+      stripColor(cursor.inspect({ lineNumber: false })),
+      dedent(`
           a¶
            ^
         `).trim(),
-      );
+    );
 
-      assertEquals(
-        stripColor(cursor.move(1).inspect({ lineNumber: false })),
-        dedent(`
+    assertEquals(
+      stripColor(cursor.move(1).inspect({ lineNumber: false })),
+      dedent(`
           b
           ^
         `).trim(),
-      );
-    });
+    );
   });
 
-  describe("max length", () => {
-    it("defaults to 40 or console width", () => {
-      // TODO: Consider refactoring to allow stubbing console width.
-    });
+  test("maxLength", () => {
+    // TODO: Consider refactoring to allow stubbing console width.
 
-    it("is configurable", () => {
-      const cursor = new TextCursor(longStr, 37);
+    const cursor = new TextCursor(longStr, 37);
 
-      assertEquals(
-        stripColor(cursor.inspect({ maxLength: 10 })),
-        dedent(`
-          …e lazy d…
-               ^
-        `).trim(),
-      );
+    assertEquals(
+      stripColor(cursor.inspect({ maxLength: 10 })),
+      dedent(`
+        …e lazy d…
+             ^
+      `).trim(),
+    );
 
-      assertEquals(
-        stripColor(cursor.inspect({ maxLength: 20 })),
-        dedent(`
-          …er the lazy dog th…
-                    ^
-        `).trim(),
-      );
-    });
+    assertEquals(
+      stripColor(cursor.inspect({ maxLength: 20 })),
+      dedent(`
+        …er the lazy dog th…
+                  ^
+      `).trim(),
+    );
   });
 
-  describe("colors", () => {
-    it("has color by default", () => {
-      const cursor = new TextCursor(str, 3);
-      const msg = cursor.inspect();
+  test("colors", () => {
+    const cursor = new TextCursor(str, 3);
+    const msg = cursor.inspect();
+    const msg2 = cursor.inspect({ colors: false });
 
-      assert(msg !== stripColor(msg));
-    });
-
-    it("is configurable", () => {
-      const cursor = new TextCursor(str, 3);
-      const msg = cursor.inspect({ colors: false });
-
-      assertEquals(msg, stripColor(msg));
-    });
+    assert(msg !== stripColor(msg));
+    assertEquals(msg2, stripColor(msg2));
   });
 });

--- a/string/dedent.test.ts
+++ b/string/dedent.test.ts
@@ -1,60 +1,62 @@
-import { assertEquals, assertThrows, describe, it } from "../_deps/testing.ts";
+import {
+  assertEquals,
+  assertThrows,
+  describe,
+  it,
+  test,
+} from "../_deps/testing.ts";
 import { dedent } from "./dedent.ts";
 
-describe("dedent", () => {
-  it('defaults to ""', () => assertEquals(dedent(""), ""));
+function assertDedent(input: string, expected: string): void {
+  assertEquals(dedent(input), expected);
+}
 
-  it("dedents single lines", () => assertEquals(dedent("  foo"), "foo"));
+test('defaults is ""', () => assertDedent("", ""));
+test("single lines", () => assertDedent("  foo", "foo"));
+test("multiple lines", () => assertDedent("  foo\n  bar", "foo\nbar"));
+test("empty lines", () => assertDedent("\n  foo\n\n  bar\n", "\nfoo\n\nbar\n"));
+test("whitespace lines", () => assertDedent("\n    X\n  \n    Y", "\nX\n\nY"));
+test("mixed indents", () => assertDedent("  a\n   b\n    c", "a\n b\n  c"));
 
-  it("dedents multiple lines", () =>
-    assertEquals(dedent("  foo\n  bar"), "foo\nbar"));
+describe("options.indentation", () => {
+  it("returns the indent", () =>
+    assertEquals(
+      dedent("  a\n   b\n    c", { returnIndentation: true }),
+      ["a\n b\n  c", "  "],
+    ));
 
-  it("handles empty lines", () =>
-    assertEquals(dedent("\n  foo\n\n  bar\n"), "\nfoo\n\nbar\n"));
+  it("reflects options.char", () =>
+    assertEquals(
+      dedent(
+        "..a\n...b\n....c",
+        { char: ".", returnIndentation: true },
+      ),
+      ["a\n.b\n..c", ".."],
+    ));
+});
 
-  it("handles whitespace lines", () =>
-    assertEquals(dedent("\n    foo\n  \n    bar\n"), "\nfoo\n\nbar\n"));
+describe("options.char", () => {
+  it("can be configured", () =>
+    assertEquals(
+      dedent("XXa\nXXXb\nXXXXc", { char: "X" }),
+      "a\nXb\nXXc",
+    ));
 
-  it("handles mixed indentation", () =>
-    assertEquals(dedent("  a\n   b\n    c"), "a\n b\n  c"));
+  it("throws if char.len > 1", () =>
+    void assertThrows(() => dedent("a", { char: "ab" })));
 
-  describe("options.indentation", () => {
-    it("returns the indentation", () =>
-      assertEquals(
-        dedent("  a\n   b\n    c", { returnIndentation: true }),
-        ["a\n b\n  c", "  "],
-      ));
+  it("throws if char.len = 0", () =>
+    void assertThrows(() => dedent("a", { char: "" })));
 
-    it("reflects options.char", () =>
-      assertEquals(
-        dedent(
-          "..a\n...b\n....c",
-          { char: ".", returnIndentation: true },
-        ),
-        ["a\n.b\n..c", ".."],
-      ));
-  });
+  it("escapes regex", () =>
+    assertEquals(
+      dedent("..a\n...b\n....c", { char: "." }),
+      "a\n.b\n..c",
+    ));
 
-  describe("options.char", () => {
-    it("can be configured", () =>
-      assertEquals(
-        dedent("XXa\nXXXb\nXXXXc", { char: "X" }),
-        "a\nXb\nXXc",
-      ));
-
-    it("throws if char.len !== 1", () =>
-      void assertThrows(() => dedent("a", { char: "ab" })));
-
-    it("escapes regex", () =>
-      assertEquals(
-        dedent("..a\n...b\n....c", { char: "." }),
-        "a\n.b\n..c",
-      ));
-
-    it("handles lines of char only", () =>
-      assertEquals(
-        dedent("....a\n..\n....c", { char: "." }),
-        "a\n\nc",
-      ));
-  });
+  it("handles char-only line", () =>
+    assertEquals(
+      dedent("....a\n..\n....c", { char: "." }),
+      "a\n\nc",
+    ));
 });

--- a/string/elide.test.ts
+++ b/string/elide.test.ts
@@ -83,14 +83,14 @@ describe("elideAround", () => {
     );
   });
 
-  it("handles indices near the start", () => {
+  it("handles early indices", () => {
     assertEquals(elideAround(digits, 2, { maxLength: 8 }), ["1234567…", 2]);
     assertEquals(elideAround(digits, 2, { maxLength: 7 }), ["123456…", 2]);
     assertEquals(elideAround(digits, 2, { maxLength: 6 }), ["12345…", 2]);
     assertEquals(elideAround(digits, 2, { maxLength: 5 }), ["1234…", 2]);
   });
 
-  it("handles indices near the end", () => {
+  it("handles late indices", () => {
     assertEquals(elideAround(digits, 7, { maxLength: 8 }), ["…4567890", 5]);
     assertEquals(elideAround(digits, 7, { maxLength: 7 }), ["…567890", 4]);
     assertEquals(elideAround(digits, 7, { maxLength: 6 }), ["…67890", 3]);

--- a/string/escape.test.ts
+++ b/string/escape.test.ts
@@ -9,11 +9,8 @@ describe("escapeFull", () => {
   });
 
   it("escapes tabs", () => assertEquals(escapeFull("\t\t"), "\\t\\t"));
-
   it("escapes vertical tabs", () => assertEquals(escapeFull("\v\v"), "\\v\\v"));
-
   it("escapes form feeds", () => assertEquals(escapeFull("\f\f"), "\\f\\f"));
-
   it("escapes backspaces", () => assertEquals(escapeFull("\b\b"), "\\b\\b"));
 });
 
@@ -25,10 +22,7 @@ describe("escapeTerse", () => {
   });
 
   it("escapes tabs", () => assertEquals(escapeTerse("\t\t"), "⇥⇥"));
-
   it("escapes vertical tabs", () => assertEquals(escapeTerse("\v\v"), "␋␋"));
-
   it("escapes form feeds", () => assertEquals(escapeTerse("\f\f"), "␌␌"));
-
   it("escapes backspaces", () => assertEquals(escapeTerse("\b\b"), "␈␈"));
 });

--- a/string/indent.test.ts
+++ b/string/indent.test.ts
@@ -1,19 +1,19 @@
-import { assertEquals, describe, it } from "../_deps/testing.ts";
+import { assertEquals, describe, test } from "../_deps/testing.ts";
 import { indent } from "./indent.ts";
 
 describe("indent", () => {
-  it('defaults to ""', () => assertEquals(indent("", ""), ""));
+  test("defaults", () => assertEquals(indent("", ""), ""));
 
-  it("indents single lines", () => assertEquals(indent("foo", " "), " foo"));
+  test("single lines", () => assertEquals(indent("foo", " "), " foo"));
 
-  it("indents multiple lines", () =>
+  test("multiple lines", () =>
     assertEquals(
       indent("foo\n bar\nbaz\n  qux", " "),
       " foo\n  bar\n baz\n   qux",
     ));
 
-  describe("indentation parameter", () => {
-    it("can be a number", () => assertEquals(indent("foo", 2), "  foo"));
-    it("can be a string", () => assertEquals(indent("foo", ".."), "..foo"));
+  test("indentation parameter", () => {
+    assertEquals(indent("foo", 2), "  foo");
+    assertEquals(indent("foo", ".."), "..foo");
   });
 });

--- a/string/sequence.test.ts
+++ b/string/sequence.test.ts
@@ -4,13 +4,12 @@ import { mostConsecutive, sequences } from "./sequence.ts";
 describe("sequences", () => {
   it("defaults to []", () => assertEquals(sequences("", ""), []));
 
-  it("returns [] on empty target", () =>
-    assertEquals(sequences("", "foo"), []));
+  it('returns [] on ""', () => assertEquals(sequences("", "foo"), []));
 
-  it("targets single characters", () =>
+  it("targets single chars", () =>
     assertEquals(sequences("o", "ofoo"), ["o", "oo"]));
 
-  it("targets multiple characters", () =>
+  it("targets multiple chars", () =>
     assertEquals(sequences("fo", "fofofosho"), ["fofofo"]));
 
   it("targets regex", () =>
@@ -20,12 +19,11 @@ describe("sequences", () => {
 describe("mostConsecutive", () => {
   it("defaults to 0", () => assertEquals(mostConsecutive("", ""), 0));
 
-  it("returns 0 on empty target", () =>
-    assertEquals(mostConsecutive("", "foo"), 0));
+  it('returns 0 on ""', () => assertEquals(mostConsecutive("", "foo"), 0));
 
-  it("targets single characters", () =>
+  it("targets single chars", () =>
     assertEquals(mostConsecutive("o", "ofoo"), 2));
 
-  it("targets multiple characters", () =>
+  it("targets multiple chars", () =>
     assertEquals(mostConsecutive("fo", "fofofosho"), 3));
 });

--- a/string/splitOn.test.ts
+++ b/string/splitOn.test.ts
@@ -9,10 +9,10 @@ describe("splitOnFirst", () => {
     assertEquals(splitOnFirst("/", "a/b/c/d"), ["a", "b/c/d"]));
 
   describe("result", () => {
-    it('is [str, ""] when no sep', () =>
+    it('is [str, ""] w/o sep', () =>
       assertEquals(splitOnFirst("", "foo"), ["foo", ""]));
 
-    it('is ["", ""] when no str', () =>
+    it('is ["", ""] w/o str', () =>
       assertEquals(splitOnFirst("X", ""), ["", ""]));
 
     it('is [str, ""] w/o match', () =>

--- a/ts/evaluate.test.ts
+++ b/ts/evaluate.test.ts
@@ -1,32 +1,22 @@
-import { assert, assertEquals, describe, it } from "../_deps/testing.ts";
+import { assert, assertEquals, describe, test } from "../_deps/testing.ts";
 import { evaluate } from "./evaluate.ts";
 
 describe("evaluate TypeScript", () => {
-  it("returns stdout", async () =>
+  test("result.stdout", async () =>
     assertEquals((await evaluate("console.log('Hello!')")).stdout, "Hello!"));
 
-  it("returns stderr", async () =>
+  test("result.stderr", async () =>
     assert((await evaluate("throw new Error('')")).stderr.length));
 
-  describe("result.success", () => {
-    it("is false when code throws ", async () =>
-      assert((await evaluate("throw new Error('')")).success === false));
-
-    it("is false on invalid input", async () =>
-      assert((await evaluate("invalid")).success === false));
-
-    it("is false on invalid types", async () =>
-      assert((await evaluate("const foo: number = ''")).success === false));
-
-    it("optionally ignores types", async () =>
-      void assert(
-        (await evaluate("const foo: number = ''", { typeCheck: false }))
-          .success,
-      ));
+  test("result.success", async () => {
+    assert((await evaluate("throw new Error('')")).success === false);
+    assert((await evaluate("invalid")).success === false);
+    assert((await evaluate("const foo: number = ''")).success === false);
+    assert((await evaluate("const foo: 1 = ''", { typeCheck: false })).success);
   });
 
-  it("respects ts-ignore comments", async () =>
+  test("ts-ignore", async () =>
     void assert(
-      (await evaluate("// @ts-ignore\n" + "const foo: number = ''")).success,
+      (await evaluate("// @ts-ignore\n" + "const foo: 1 = ''")).success,
     ));
 });


### PR DESCRIPTION
- Removes some invalid test cases in `md/codeBlock/indented.test.ts` which I uncovered during the parser work.

- Re-exports `it` as `test` to mirror the Jest API.

  This small name change makes it easy to radically shorten many clumsy test messages while still keeping the test code legible.

    ```ts
    // Before
    it("works with synchronous predicates", 
    it("finds longest strings in a Set", 

    // After
    test("synchronous predicates", 
    test("w/ Set", 
    ```

- Removes many `describe` blocks when they were the only top-level block

- Collapsed many assertions into single tests when their contents were exhaustive explanations of behavior that did not need to be spelled out.

- Shortens all test messages, bringing every test log entry under 40 characters (half a terminal) for easy side-by-side with files on small displays.