### PR TITLE
feat(array/types): `Flat` respects non-tuple arrays

### DIFF
--- a/array/types.ts
+++ b/array/types.ts
@@ -22,11 +22,22 @@ export type Fill<T extends readonly unknown[], Value> = {
  * `Array.prototype.flat()`.
  *
  * @example
- * const items: Flat<[1, 2, [3, [4], 5]]> = [1, 2, 3, [4], 5]; */
+ * type Tup = Flat<[1, 2, [3, [4], 5]]> // [1, 2, 3, [4], 5];
+ * type Arr = Flat<number[][]> // number[]
+ * type Arr2D = Flat<number[][]> // number[]
+ * type Mix = Flat<["A", ["B", "C"][]]> // ["A", ...["B", "C"][]] */
 export type Flat<T extends readonly unknown[]> = T extends
-  readonly [infer Head, ...infer Tail]
-  ? Head extends unknown[] ? [...Head, ...Flat<Tail>]
-  : [Head, ...Flat<Tail>]
+  readonly [infer Head, ...infer Tail] // If the first and rest are inferable...
+  ? Head extends unknown[] // ...and the first is an array...
+    ? [...Head, ...Flat<Tail>] // ...spread it then recurse on the rest.
+  : [Head, ...Flat<Tail>] // Otherwise, keep the first and recurse.
+  //
+  : T extends readonly [] ? [] // It T is empty, return an empty array.
+  //
+  : T extends Array<infer Item extends unknown> // If T is a non-tuple array...
+    ? Item extends unknown[] // ...and it contains an array...
+      ? [...Item] // ...spread it.
+    : Item[] // Otherwise, keep it.
   : [];
 
 /** Represents an array reversed, analogous to `Array.prototype.reverse()`.


### PR DESCRIPTION
Turns out the current implementation only handles tuples. `T extends [infer Head, infer ...Tail]` only pattern-matches against strings and tuples, where the 0th element can be inferred from the rest. Separate handling is required for non-tuple arrays, which this PR provides alongside examples.

- [Before Playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAYgNgQ2AHgCpQgD2BAdgEwGcoAnCBfAe1zhCgFdcBrXSgd1wG0BdAPigC8UdFhwFCAKCilyVGnU4BLXADMIJKAAlZAGigA6Q8rUbUCRXG5SoAfi2yM2PEQbNWHHraidD+7RT1feCQ0czheK2kALm9-fEDDYJQzCwjrGJ4AbgkJUEhhejA4aCEk5E4AIgBBCr1KgCEK7j4oAHpWqDZKEiZJPOgqkg1SxBRcegBbACN1Hn42juN1MnwoBGIeXPABoYAmABFBWFHkcenZ7jnpdqgloYhV9e8rfqgAWUVMI7LKmrqKxp6CoAYSaPBaC063V6EiAA)

- [After Playground](https://www.typescriptlang.org/play?#code/KYDwDg9gTgLgBDAnmYcBiAbAhjAPAFTlBmADsATAZzimC3IlI0TgFdSBrUiAd1IG0AugD44AXjiFiZKgCg4NOgyYt+AS1IAzYFDgAJJQBo4AOjMbtu-FjUZB8uAH59SoiBIVq7LrwH2FCs78ZiYG9MYhmDgENhjC-nAAXHD8YeQRZlF41rbxDslS7jLUtPSMzCmCTpX5km4eVHAAglBQWIi4FjpwAJIkALb1xWyc3HzCDoG9A0OeIz58QpMBQSF9wP0JCsnr-UvblQDcsrJIKJKsYBioElm4-ABETQ-GjwBCD4IicAD0P3A8aAcSinZCoFq6W7YPCkVj9ABGOiEol+-y6rWA5DgWGosIRSPsZ3BrQATAARcToaG4PGIqBCZEKP5wdG0LE4uC0gmg84AWTUIEpd0ez1eDw+xgeAGFPkJvqiWVodGzsdQRS9TGZ3hrpbKvrIgA)