### PR TITLE
feat(string/TextCursor): visualize spaces as `·`

### DIFF
--- a/string/TextCursor.test.ts
+++ b/string/TextCursor.test.ts
@@ -94,7 +94,7 @@ describe("inspect()", () => {
     assertEquals(
       stripColor(new TextCursor(str, 3).inspect()),
       dedent(`
-        feat: example
+        feat:·example
            ^
       `).trim(),
     ));
@@ -103,7 +103,7 @@ describe("inspect()", () => {
     assertEquals(
       stripColor(new TextCursor(longStr, 37).inspect({ maxLength })),
       dedent(`
-        … jumps over the lazy dog then does it…
+        …·jumps·over·the·lazy·dog·then·does·it…
                            ^
       `).trim(),
     ));
@@ -152,7 +152,7 @@ describe("inspect()", () => {
     assertEquals(
       stripColor(cursor.inspect({ maxLength: 10 })),
       dedent(`
-        …e lazy d…
+        …e·lazy·d…
              ^
       `).trim(),
     );
@@ -160,7 +160,7 @@ describe("inspect()", () => {
     assertEquals(
       stripColor(cursor.inspect({ maxLength: 20 })),
       dedent(`
-        …er the lazy dog th…
+        …er·the·lazy·dog·th…
                   ^
       `).trim(),
     );

--- a/string/TextCursor.ts
+++ b/string/TextCursor.ts
@@ -1,4 +1,4 @@
-import { blue } from "../_deps/fmt.ts";
+import { blue, gray } from "../_deps/fmt.ts";
 import { consoleWidth } from "../cli/consoleSize.ts";
 import { Text } from "./Text.ts";
 import { elideAround } from "./elide.ts";
@@ -93,12 +93,14 @@ export class TextCursor extends Text {
 
     maxLength = maxLength - lineMarker.length;
     const [elided, offset] = elideAround(this.line, column - 1, { maxLength });
-    const escaped = escapeTerse(elided);
     const pointerSpacing = " ".repeat(offset + lineMarker.length);
 
+    const escaped = escapeTerse(elided);
+    const str = escaped.replaceAll(" ", colors ? gray("·") : "·");
+
     return colors
-      ? `${blue(lineMarker)}${escaped}\n${pointerSpacing}${blue("^")}`
-      : `${lineMarker}${escaped}\n${pointerSpacing}^`;
+      ? `${blue(lineMarker)}${str}\n${pointerSpacing}${blue("^")}`
+      : `${lineMarker}${str}\n${pointerSpacing}^`;
   }
 
   toString(): string {
@@ -108,7 +110,10 @@ export class TextCursor extends Text {
   }
 
   /** The function called by `console.log()` in Deno. */
-  [Symbol.for("Deno.customInspect")](opts: Deno.InspectOptions): string {
+  [Symbol.for("Deno.customInspect")](
+    _: unknown,
+    opts: Deno.InspectOptions,
+  ): string {
     return this.inspect(opts);
   }
 }


### PR DESCRIPTION
During parser work for indented code blocks, the inability to see spaces was a significant hindrance.

I also found that the signature for the Deno.customInspect function was incorrectly wired.