### PR TITLE
refactor(md/codeBlock): remove unnecessary `Details` properties

### DIFF
--- a/md/codeBlock/fenced.test.ts
+++ b/md/codeBlock/fenced.test.ts
@@ -51,11 +51,6 @@ describe("create", () => {
 describe("parse", () => {
   test("result.type", () => assertEquals(parse("```\n```").type, "fenced"));
 
-  test("result.char", () => {
-    assertEquals(parse("```\n```").char, "`");
-    assertEquals(parse("~~~\n~~~").char, "~");
-  });
-
   test("result.fence", () => {
     assertEquals(parse("```\n```").fence, "```");
     assertEquals(parse("~~~\n~~~").fence, "~~~");
@@ -82,7 +77,6 @@ describe("parse", () => {
       parse("```\r\nHello!\r\n```"),
       {
         type: "fenced",
-        char: "`",
         fence: "```",
         code: "Hello!",
       },

--- a/md/codeBlock/fenced.ts
+++ b/md/codeBlock/fenced.ts
@@ -8,7 +8,6 @@ import type { SearchResult } from "./types.ts";
 export type FencedCodeBlockDetails = Pretty<
   & {
     type: "fenced";
-    char: FenceChar;
     fence: string;
     code: string;
   }
@@ -59,10 +58,9 @@ export function parse(codeBlock: string): FencedCodeBlockDetails {
   const match = codeBlock.match(FENCED_CODE_BLOCK_REGEX);
   const { fence, infoString: _infoString, code = "" } = match?.groups ?? {};
   const { lang, meta } = infoString.parse(_infoString);
-  const char = fence[0] as FenceChar;
   const type = "fenced" as const;
 
-  const data: FencedCodeBlockDetails = { type, char, fence, code };
+  const data: FencedCodeBlockDetails = { type, fence, code };
 
   if (lang) data.lang = lang;
   if (meta) data.meta = meta;

--- a/md/codeBlock/indented.test.ts
+++ b/md/codeBlock/indented.test.ts
@@ -26,9 +26,6 @@ describe("parse", () => {
     test("mixed indents", () => assertParse("     foo\n    bar", " foo\nbar"));
     test("blank lines", () => assertParse("    X\n\n\n    Y", "X\n\n\nY"));
   });
-
-  test("result.indentation", () =>
-    assertEquals(parse("      foo").indentation, "      "));
 });
 
 test("findAll", () =>

--- a/md/codeBlock/indented.ts
+++ b/md/codeBlock/indented.ts
@@ -6,7 +6,6 @@ import { SearchResult } from "./types.ts";
 export type IndentedCodeBlockDetails = {
   type: "indented";
   code: string;
-  indentation: string;
 };
 
 export function create(code: string): string {
@@ -27,9 +26,8 @@ export function parse(codeBlock: string): IndentedCodeBlockDetails {
     .replace(/(^\n+|\n+$)/g, "");
 
   const type = "indented" as const;
-  const indentation = " ".repeat(indent);
 
-  return { type, code, indentation };
+  return { type, code };
 }
 
 export function findAll(markdown: string): SearchResult[] {

--- a/md/codeBlock/parse.test.ts
+++ b/md/codeBlock/parse.test.ts
@@ -15,7 +15,6 @@ test("parses fenced blocks", () =>
     parse("```lang meta data\nfoo\nbar\n```"),
     {
       type: "fenced",
-      char: "`",
       fence: "```",
       lang: "lang",
       meta: "meta data",

--- a/md/codeBlock/parse.test.ts
+++ b/md/codeBlock/parse.test.ts
@@ -6,7 +6,6 @@ test("parses indented blocks", () =>
     parse("    foo\n    bar"),
     {
       type: "indented",
-      indentation: "    ",
       code: "foo\nbar",
     },
   ));


### PR DESCRIPTION
- Turns out that indented blocks are supposed to be exactly 4-space indented, and additional spaces are part of the content. Therefore `IndentedCodeBlockDetails["indentation"]` should be `"    "` every time and so is meaningless once the implementation is corrected.

- `FencedCodeBlockDetails["char"]` was originally provided as output from `fenced.parse()` in the hopes that the `parse` and `create` functions could accept each other's outputs as inputs, but that didn't happen. Now it's just chaff that's trivially derivable from `FencedCodeBlockDetails["fence"]`